### PR TITLE
Fix issues found by linter.

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -164,9 +164,9 @@ func (u *UUID) decodeBraced(t []byte) (err error) {
 func (u *UUID) decodeURN(t []byte) (err error) {
 	total := len(t)
 
-	urn_uuid_prefix := t[:9]
+	urnUUIDPrefix := t[:9]
 
-	if !bytes.Equal(urn_uuid_prefix, urnPrefix) {
+	if !bytes.Equal(urnUUIDPrefix, urnPrefix) {
 		return fmt.Errorf("uuid: incorrect UUID format: %s", t)
 	}
 

--- a/generator.go
+++ b/generator.go
@@ -215,7 +215,8 @@ func (g *rfc4122Generator) getClockSequence() (uint64, uint16, error) {
 func (g *rfc4122Generator) getHardwareAddr() ([]byte, error) {
 	var err error
 	g.hardwareAddrOnce.Do(func() {
-		if hwAddr, err := g.hwAddrFunc(); err == nil {
+		var hwAddr net.HardwareAddr
+		if hwAddr, err = g.hwAddrFunc(); err == nil {
 			copy(g.hardwareAddr[:], hwAddr)
 			return
 		}


### PR DESCRIPTION
Fixes name of variable which does not follow Go convention (minor).
Fixes bug where error shadowing causes a hardware address get error to be ignored (major).