### PR TITLE
Rewrite default NewV2 to generate correct output if UID/GID are changed at runtime

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -44,9 +44,6 @@ type hwAddrFunc func() (net.HardwareAddr, error)
 
 var (
 	global = newRFC4122Generator()
-
-	posixUID = uint32(os.Getuid())
-	posixGID = uint32(os.Getgid())
 )
 
 // NewV1 returns UUID based on current timestamp and MAC address.
@@ -140,9 +137,9 @@ func (g *rfc4122Generator) NewV2(domain byte) (UUID, error) {
 
 	switch domain {
 	case DomainPerson:
-		binary.BigEndian.PutUint32(u[:], posixUID)
+		binary.BigEndian.PutUint32(u[:], uint32(os.Getuid()))
 	case DomainGroup:
-		binary.BigEndian.PutUint32(u[:], posixGID)
+		binary.BigEndian.PutUint32(u[:], uint32(os.Getgid()))
 	}
 
 	u[9] = domain


### PR DESCRIPTION
Previously, the package used the UID/GID from package initialization time. However the user may call syscall.Setuid at runtime.

While calling this at runtime is the correct behavior, it adds 2 syscalls per UUID created. This is a performance/correctness tradeoff.