### PR TITLE
Covered UUID.decodePlain() with wrong input with a test

### DIFF
--- a/codec_test.go
+++ b/codec_test.go
@@ -222,6 +222,16 @@ func TestMarshalText(t *testing.T) {
 	}
 }
 
+func TestDecodePlainWithWrongLength(t *testing.T) {
+	arg := []byte{'4', '2'}
+
+	u := UUID{}
+
+	if u.decodePlain(arg) == nil {
+		t.Errorf("%v.decodePlain(%q): should return error, but it did not", u, arg)
+	}
+}
+
 var stringBenchmarkSink string
 
 func BenchmarkString(b *testing.B) {


### PR DESCRIPTION
The `TestDecodePlainWithWrongLength` runs unexported method since there is no other way to reach that line.

It's a substitution for the https://github.com/gofrs/uuid/pull/22 which I accidentally closed via deleting my branch (instead of hard-push'ing it)