### PR TITLE
Add Time() and Nanos() methods

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -30,10 +30,10 @@
 package uuid
 
 import (
-	"encoding/hex"
 	"encoding/binary"
-	"time"
+	"encoding/hex"
 	"fmt"
+	"time"
 )
 
 // Size of a UUID in bytes.
@@ -76,8 +76,8 @@ const _100nsPerSecond = 10000000
 
 // Time returns the UTC time.Time representation of a Timestamp
 func (t Timestamp) Time() (time.Time, error) {
-	secs := uint64(t)/_100nsPerSecond
-	nsecs := 100 * (uint64(t)%_100nsPerSecond)
+	secs := uint64(t) / _100nsPerSecond
+	nsecs := 100 * (uint64(t) % _100nsPerSecond)
 	return time.Unix(int64(secs)-(epochStart/_100nsPerSecond), int64(nsecs)), nil
 }
 
@@ -91,7 +91,7 @@ func TimestampFromV1(u UUID) (Timestamp, error) {
 	low := binary.BigEndian.Uint32(u[0:4])
 	mid := binary.BigEndian.Uint16(u[4:6])
 	hi := binary.BigEndian.Uint16(u[6:8]) & 0xfff
-	return Timestamp(low) + (Timestamp(mid) << 32) + (Timestamp(hi) << 48), nil
+	return Timestamp(uint64(low) + (uint64(mid) << 32) + (uint64(hi) << 48)), nil
 }
 
 // String parse helpers.

--- a/uuid.go
+++ b/uuid.go
@@ -31,6 +31,9 @@ package uuid
 
 import (
 	"encoding/hex"
+	"encoding/binary"
+	"time"
+	"fmt"
 )
 
 // Size of a UUID in bytes.
@@ -63,6 +66,33 @@ const (
 	DomainGroup
 	DomainOrg
 )
+
+// Timestamp is the count of 100-nanosecond intervals since 00:00:00.00,
+// 15 October 1582 within a V1 UUID. This type has no meaning for V2-V5
+// UUIDs since they don't have an embedded timestamp.
+type Timestamp uint64
+
+const _100nsPerSecond = 10000000
+
+// Time returns the UTC time.Time representation of a Timestamp
+func (t Timestamp) Time() (time.Time, error) {
+	secs := uint64(t)/_100nsPerSecond
+	nsecs := 100 * (uint64(t)%_100nsPerSecond)
+	return time.Unix(int64(secs)-(epochStart/_100nsPerSecond), int64(nsecs)), nil
+}
+
+// TimestampFromV1 returns the Timestamp embedded within a V1 UUID.
+// Returns an error if the UUID is any version other than 1.
+func TimestampFromV1(u UUID) (Timestamp, error) {
+	if u.Version() != 1 {
+		err := fmt.Errorf("uuid: %s is version %d, not version 1", u, u.Version())
+		return 0, err
+	}
+	low := binary.BigEndian.Uint32(u[0:4])
+	mid := binary.BigEndian.Uint16(u[4:6])
+	hi := binary.BigEndian.Uint16(u[6:8]) & 0xfff
+	return Timestamp(low) + (Timestamp(mid) << 32) + (Timestamp(hi) << 48), nil
+}
 
 // String parse helpers.
 var (

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -137,21 +137,21 @@ func TestMust(t *testing.T) {
 
 func TestTimeFromTimestamp(t *testing.T) {
 	tests := []struct {
-		t Timestamp
+		t    Timestamp
 		want time.Time
 	}{
 		// a zero timestamp represents October 15, 1582 at midnight UTC
-		{ t: Timestamp(0), want: time.Date(1582, 10, 15, 0, 0, 0, 0, time.UTC) },
+		{t: Timestamp(0), want: time.Date(1582, 10, 15, 0, 0, 0, 0, time.UTC)},
 		// a one value is 100ns later
-		{ t: Timestamp(1), want: time.Date(1582, 10, 15, 0, 0, 0, 100, time.UTC) },
+		{t: Timestamp(1), want: time.Date(1582, 10, 15, 0, 0, 0, 100, time.UTC)},
 		// 10 million 100ns intervals later is one second
-		{ t: Timestamp(10000000), want: time.Date(1582, 10, 15, 0, 0, 1, 0, time.UTC) },
-		{ t: Timestamp(60*10000000), want: time.Date(1582, 10, 15, 0, 1, 0, 0, time.UTC) },
-		{ t: Timestamp(60*60*10000000), want: time.Date(1582, 10, 15, 1, 0, 0, 0, time.UTC) },
-		{ t: Timestamp(24*60*60*10000000), want: time.Date(1582, 10, 16, 0, 0, 0, 0, time.UTC) },
-		{ t: Timestamp(365*24*60*60*10000000), want: time.Date(1583, 10, 15, 0, 0, 0, 0, time.UTC) },
+		{t: Timestamp(10000000), want: time.Date(1582, 10, 15, 0, 0, 1, 0, time.UTC)},
+		{t: Timestamp(60 * 10000000), want: time.Date(1582, 10, 15, 0, 1, 0, 0, time.UTC)},
+		{t: Timestamp(60 * 60 * 10000000), want: time.Date(1582, 10, 15, 1, 0, 0, 0, time.UTC)},
+		{t: Timestamp(24 * 60 * 60 * 10000000), want: time.Date(1582, 10, 16, 0, 0, 0, 0, time.UTC)},
+		{t: Timestamp(365 * 24 * 60 * 60 * 10000000), want: time.Date(1583, 10, 15, 0, 0, 0, 0, time.UTC)},
 		// maximum timestamp value in a UUID is the year 5236
-		{ t: Timestamp(uint64(1<<60 - 1)), want: time.Date(5236, 03, 31, 21, 21, 0, 684697500, time.UTC) },
+		{t: Timestamp(uint64(1<<60 - 1)), want: time.Date(5236, 03, 31, 21, 21, 0, 684697500, time.UTC)},
 	}
 	for _, tt := range tests {
 		got, _ := tt.t.Time()
@@ -163,14 +163,14 @@ func TestTimeFromTimestamp(t *testing.T) {
 
 func TestTimestampFromV1(t *testing.T) {
 	tests := []struct {
-		u UUID
-		want Timestamp
+		u       UUID
+		want    Timestamp
 		wanterr bool
 	}{
 		{u: Must(NewV4()), wanterr: true},
 		{u: Must(FromString("00000000-0000-1000-0000-000000000000")), want: 0},
 		{u: Must(FromString("424f137e-a2aa-11e8-98d0-529269fb1459")), want: 137538640775418750},
-		{u: Must(FromString("ffffffff-ffff-1fff-ffff-ffffffffffff")), want: Timestamp(1<<60-1)},
+		{u: Must(FromString("ffffffff-ffff-1fff-ffff-ffffffffffff")), want: Timestamp(1<<60 - 1)},
 	}
 	for _, tt := range tests {
 		got, goterr := TimestampFromV1(tt.u)
@@ -181,4 +181,3 @@ func TestTimestampFromV1(t *testing.T) {
 		}
 	}
 }
-

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -25,6 +25,7 @@ import (
 	"bytes"
 	"fmt"
 	"testing"
+	"time"
 )
 
 func TestUUID(t *testing.T) {
@@ -133,3 +134,51 @@ func TestMust(t *testing.T) {
 	}
 	Must(fn())
 }
+
+func TestTimeFromTimestamp(t *testing.T) {
+	tests := []struct {
+		t Timestamp
+		want time.Time
+	}{
+		// a zero timestamp represents October 15, 1582 at midnight UTC
+		{ t: Timestamp(0), want: time.Date(1582, 10, 15, 0, 0, 0, 0, time.UTC) },
+		// a one value is 100ns later
+		{ t: Timestamp(1), want: time.Date(1582, 10, 15, 0, 0, 0, 100, time.UTC) },
+		// 10 million 100ns intervals later is one second
+		{ t: Timestamp(10000000), want: time.Date(1582, 10, 15, 0, 0, 1, 0, time.UTC) },
+		{ t: Timestamp(60*10000000), want: time.Date(1582, 10, 15, 0, 1, 0, 0, time.UTC) },
+		{ t: Timestamp(60*60*10000000), want: time.Date(1582, 10, 15, 1, 0, 0, 0, time.UTC) },
+		{ t: Timestamp(24*60*60*10000000), want: time.Date(1582, 10, 16, 0, 0, 0, 0, time.UTC) },
+		{ t: Timestamp(365*24*60*60*10000000), want: time.Date(1583, 10, 15, 0, 0, 0, 0, time.UTC) },
+		// maximum timestamp value in a UUID is the year 5236
+		{ t: Timestamp(uint64(1<<60 - 1)), want: time.Date(5236, 03, 31, 21, 21, 0, 684697500, time.UTC) },
+	}
+	for _, tt := range tests {
+		got, _ := tt.t.Time()
+		if !got.Equal(tt.want) {
+			t.Errorf("%v.Time() == %v, want %v", tt.t, got, tt.want)
+		}
+	}
+}
+
+func TestTimestampFromV1(t *testing.T) {
+	tests := []struct {
+		u UUID
+		want Timestamp
+		wanterr bool
+	}{
+		{u: Must(NewV4()), wanterr: true},
+		{u: Must(FromString("00000000-0000-1000-0000-000000000000")), want: 0},
+		{u: Must(FromString("424f137e-a2aa-11e8-98d0-529269fb1459")), want: 137538640775418750},
+		{u: Must(FromString("ffffffff-ffff-1fff-ffff-ffffffffffff")), want: Timestamp(1<<60-1)},
+	}
+	for _, tt := range tests {
+		got, goterr := TimestampFromV1(tt.u)
+		if tt.wanterr && goterr == nil {
+			t.Errorf("TimestampFromV1(%v) want error, got %v", tt.u, got)
+		} else if tt.want != got {
+			t.Errorf("TimestampFromV1(%v) got %v, want %v", tt.u, got, tt.want)
+		}
+	}
+}
+


### PR DESCRIPTION
These methods can be used to extract time values
from V1 UUIDs

Originally added as https://github.com/satori/go.uuid/pull/50
