### PR TITLE
Improve Equal package function

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -30,7 +30,6 @@
 package uuid
 
 import (
-	"bytes"
 	"encoding/hex"
 )
 
@@ -83,9 +82,9 @@ var (
 	NamespaceX500 = Must(FromString("6ba7b814-9dad-11d1-80b4-00c04fd430c8"))
 )
 
-// Equal returns true if u1 and u2 equals, otherwise returns false.
-func Equal(u1 UUID, u2 UUID) bool {
-	return bytes.Equal(u1[:], u2[:])
+// Equal returns true if a and b are equivalent.
+func Equal(a UUID, b UUID) bool {
+	return a == b
 }
 
 // Version returns the algorithm version used to generate the UUID.


### PR DESCRIPTION
This change makes some improvements to the Equal package function:

- updates function comment to read better
- changes the argument variables to `a` and `b`, instead of `u1` and `u2`
- compare the arrays directly, instead of converting to slices and comparing

Fixes #33

Signed-off-by: Tim Heckman <t@heckman.io>