### PR TITLE
Deprecate the Equal package function

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -83,6 +83,9 @@ var (
 )
 
 // Equal returns true if a and b are equivalent.
+//
+// Deprecated: this function is deprecated and will be removed in a future major
+// version, as values of type UUID are directly comparable using `==`.
 func Equal(a UUID, b UUID) bool {
 	return a == b
 }


### PR DESCRIPTION
This deprecates the `Equal` package function, in favor of consumers using the
`==` comparison operator themselves between two `UUID` values. Because the UUID
value is an array type, there is no reason for the helper function.

The intent is to remove this as part of a v2.x => v3.x release.

Fixes #35

Signed-off-by: Tim Heckman <t@heckman.io>