### PR TITLE
Add JSON (Un)marshaling methods on NullUUID type

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -22,7 +22,9 @@
 package uuid
 
 import (
+	"bytes"
 	"database/sql/driver"
+	"encoding/json"
 	"fmt"
 )
 
@@ -75,4 +77,29 @@ func (u *NullUUID) Scan(src interface{}) error {
 	// Delegate to UUID Scan function
 	u.Valid = true
 	return u.UUID.Scan(src)
+}
+
+// MarshalJSON marshals the NullUUID as null or the nested UUID
+func (u NullUUID) MarshalJSON() ([]byte, error) {
+	if !u.Valid {
+		return json.Marshal(nil)
+	}
+
+	return json.Marshal(u.UUID)
+}
+
+// UnmarshalJSON unmarshals a NullUUID
+func (u *NullUUID) UnmarshalJSON(b []byte) error {
+	if bytes.Equal(b, []byte("null")) {
+		u.UUID, u.Valid = Nil, false
+		return nil
+	}
+
+	if err := json.Unmarshal(b, &u.UUID); err != nil {
+		return err
+	}
+
+	u.Valid = true
+
+	return nil
 }

--- a/sql_test.go
+++ b/sql_test.go
@@ -21,7 +21,11 @@
 
 package uuid
 
-import "testing"
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
 
 func TestSQL(t *testing.T) {
 	t.Run("Value", testSQLValue)
@@ -106,59 +110,196 @@ func testSQLScanNil(t *testing.T) {
 }
 
 func TestNullUUID(t *testing.T) {
-	t.Run("NilValue", func(t *testing.T) {
-		nu := NullUUID{}
-		got, err := nu.Value()
-		if got != nil {
-			t.Errorf("null NullUUID.Value returned non-nil driver.Value")
-		}
-		if err != nil {
-			t.Errorf("null NullUUID.Value returned non-nil error")
-		}
+	t.Run("Value", func(t *testing.T) {
+		t.Run("Nil", testNullUUIDValueNil)
+		t.Run("Valid", testNullUUIDValueValid)
 	})
-	t.Run("ValidValue", func(t *testing.T) {
-		nu := NullUUID{
-			Valid: true,
-			UUID:  codecTestUUID,
-		}
-		got, err := nu.Value()
-		if err != nil {
-			t.Fatal(err)
-		}
-		s, ok := got.(string)
-		if !ok {
-			t.Errorf("Value() returned %T, want string", got)
-		}
-		want := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
-		if s != want {
-			t.Errorf("%v.Value() == %s, want %s", nu, s, want)
-		}
+
+	t.Run("Scan", func(t *testing.T) {
+		t.Run("Nil", testNullUUIDScanNil)
+		t.Run("Valid", testNullUUIDScanValid)
 	})
-	t.Run("ScanValid", func(t *testing.T) {
-		s := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
-		u := NullUUID{}
-		err := u.Scan(s)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !u.Valid {
-			t.Errorf("Valid == false after Scan(%q)", s)
-		}
-		if u.UUID != codecTestUUID {
-			t.Errorf("UUID == %v after Scan(%q), want %v", u.UUID, s, codecTestUUID)
-		}
+
+	t.Run("MarshalJSON", func(t *testing.T) {
+		t.Run("Nil", testNullUUIDMarshalJSONNil)
+		t.Run("Null", testNullUUIDMarshalJSONNull)
+		t.Run("Valid", testNullUUIDMarshalJSONValid)
 	})
-	t.Run("ScanNil", func(t *testing.T) {
-		u := NullUUID{}
-		err := u.Scan(nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if u.Valid {
-			t.Error("NullUUID is valid after Scan(nil)")
-		}
-		if u.UUID != Nil {
-			t.Errorf("NullUUID.UUID is %v after Scan(nil) want Nil", u.UUID)
-		}
+
+	t.Run("UnmarshalJSON", func(t *testing.T) {
+		t.Run("Nil", testNullUUIDUnmarshalJSONNil)
+		t.Run("Null", testNullUUIDUnmarshalJSONNull)
+		t.Run("Valid", testNullUUIDUnmarshalJSONValid)
+		t.Run("Malformed", testNullUUIDUnmarshalJSONMalformed)
 	})
+}
+
+func testNullUUIDValueNil(t *testing.T) {
+	nu := NullUUID{}
+	got, err := nu.Value()
+	if got != nil {
+		t.Errorf("null NullUUID.Value returned non-nil driver.Value")
+	}
+	if err != nil {
+		t.Errorf("null NullUUID.Value returned non-nil error")
+	}
+}
+
+func testNullUUIDValueValid(t *testing.T) {
+	nu := NullUUID{
+		Valid: true,
+		UUID:  codecTestUUID,
+	}
+	got, err := nu.Value()
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, ok := got.(string)
+	if !ok {
+		t.Errorf("Value() returned %T, want string", got)
+	}
+	want := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	if s != want {
+		t.Errorf("%v.Value() == %s, want %s", nu, s, want)
+	}
+}
+
+func testNullUUIDScanNil(t *testing.T) {
+	u := NullUUID{}
+	err := u.Scan(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.Valid {
+		t.Error("NullUUID is valid after Scan(nil)")
+	}
+	if u.UUID != Nil {
+		t.Errorf("NullUUID.UUID is %v after Scan(nil) want Nil", u.UUID)
+	}
+}
+
+func testNullUUIDScanValid(t *testing.T) {
+	s := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	u := NullUUID{}
+	err := u.Scan(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !u.Valid {
+		t.Errorf("Valid == false after Scan(%q)", s)
+	}
+	if u.UUID != codecTestUUID {
+		t.Errorf("UUID == %v after Scan(%q), want %v", u.UUID, s, codecTestUUID)
+	}
+}
+
+func testNullUUIDMarshalJSONNil(t *testing.T) {
+	u := NullUUID{Valid: true}
+
+	data, err := u.MarshalJSON()
+	if err != nil {
+		t.Fatalf("(%#v).MarshalJSON err want: <nil>, got: %v", u, err)
+	}
+
+	dataStr := string(data)
+
+	if dataStr != fmt.Sprintf("%q", Nil) {
+		t.Fatalf("(%#v).MarshalJSON value want: %s, got: %s", u, Nil, dataStr)
+	}
+}
+
+func testNullUUIDMarshalJSONValid(t *testing.T) {
+	u := NullUUID{
+		Valid: true,
+		UUID:  codecTestUUID,
+	}
+
+	data, err := u.MarshalJSON()
+	if err != nil {
+		t.Fatalf("(%#v).MarshalJSON err want: <nil>, got: %v", u, err)
+	}
+
+	dataStr := string(data)
+
+	if dataStr != fmt.Sprintf("%q", codecTestUUID) {
+		t.Fatalf("(%#v).MarshalJSON value want: %s, got: %s", u, codecTestUUID, dataStr)
+	}
+}
+
+func testNullUUIDMarshalJSONNull(t *testing.T) {
+	u := NullUUID{}
+
+	data, err := u.MarshalJSON()
+	if err != nil {
+		t.Fatalf("(%#v).MarshalJSON err want: <nil>, got: %v", u, err)
+	}
+
+	dataStr := string(data)
+
+	if dataStr != "null" {
+		t.Fatalf("(%#v).MarshalJSON value want: %s, got: %s", u, "null", dataStr)
+	}
+}
+
+func testNullUUIDUnmarshalJSONNil(t *testing.T) {
+	var u NullUUID
+
+	data := []byte(`"00000000-0000-0000-0000-000000000000"`)
+
+	if err := json.Unmarshal(data, &u); err != nil {
+		t.Fatalf("json.Unmarshal err = %v, want <nil>", err)
+	}
+
+	if !u.Valid {
+		t.Fatalf("u.Valid = false, want true")
+	}
+
+	if u.UUID != Nil {
+		t.Fatalf("u.UUID = %v, want %v", u.UUID, Nil)
+	}
+}
+
+func testNullUUIDUnmarshalJSONNull(t *testing.T) {
+	var u NullUUID
+
+	data := []byte(`null`)
+
+	if err := json.Unmarshal(data, &u); err != nil {
+		t.Fatalf("json.Unmarshal err = %v, want <nil>", err)
+	}
+
+	if u.Valid {
+		t.Fatalf("u.Valid = true, want false")
+	}
+
+	if u.UUID != Nil {
+		t.Fatalf("u.UUID = %v, want %v", u.UUID, Nil)
+	}
+}
+func testNullUUIDUnmarshalJSONValid(t *testing.T) {
+	var u NullUUID
+
+	data := []byte(`"6ba7b810-9dad-11d1-80b4-00c04fd430c8"`)
+
+	if err := json.Unmarshal(data, &u); err != nil {
+		t.Fatalf("json.Unmarshal err = %v, want <nil>", err)
+	}
+
+	if !u.Valid {
+		t.Fatalf("u.Valid = false, want true")
+	}
+
+	if u.UUID != codecTestUUID {
+		t.Fatalf("u.UUID = %v, want %v", u.UUID, Nil)
+	}
+}
+
+func testNullUUIDUnmarshalJSONMalformed(t *testing.T) {
+	var u NullUUID
+
+	data := []byte(`257`)
+
+	if err := json.Unmarshal(data, &u); err == nil {
+		t.Fatal("json.Unmarshal err = <nil>, want error")
+	}
 }


### PR DESCRIPTION
This commit adapts satori/go.uuid#44 for our fork of the
original project. This brings JSON Marshaling and Unmarshaling to the
`uuid.NullUUID` type used for use with SQL databases.

This is needed because `uuid.NullUUID` is a shim around `uuid.UUID`, providing
the information needed by the `database/sql` package to support storing the
value in a nullable column. Without these methods, the type gets converted
unnecessarily to a different format than the standard `uuid.UUID` type.
