### PR TITLE
Remove the deprecated Equal function (in preparation for v3.0.0)

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -82,14 +82,6 @@ var (
 	NamespaceX500 = Must(FromString("6ba7b814-9dad-11d1-80b4-00c04fd430c8"))
 )
 
-// Equal returns true if a and b are equivalent.
-//
-// Deprecated: this function is deprecated and will be removed in a future major
-// version, as values of type UUID are directly comparable using `==`.
-func Equal(a UUID, b UUID) bool {
-	return a == b
-}
-
 // Version returns the algorithm version used to generate the UUID.
 func (u UUID) Version() byte {
 	return u[6] >> 4

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -113,15 +113,6 @@ func testUUIDSetVariant(t *testing.T) {
 	}
 }
 
-func TestEqual(t *testing.T) {
-	if !Equal(NamespaceDNS, NamespaceDNS) {
-		t.Errorf("NamespaceDNS (%v) != NamespaceDNS (%v)", NamespaceDNS, NamespaceDNS)
-	}
-	if Equal(NamespaceDNS, NamespaceURL) {
-		t.Errorf("NamespaceDNS (%v) == NamespaceURL (%v)", NamespaceDNS, NamespaceURL)
-	}
-}
-
 func TestMust(t *testing.T) {
 	sentinel := fmt.Errorf("uuid: sentinel error")
 	defer func() {


### PR DESCRIPTION
Because the `Equal` function provided no value, we decided to remove it at the
time of the 2.1.0 release. This change actions that removal to prepare for the
v3.0.0 release.

Fixes #37

Signed-off-by: Tim Heckman <t@heckman.io>