### PR TITLE
Tiny code simplification in codec

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -125,7 +125,7 @@ func (u *UUID) decodeCanonical(t []byte) error {
 		return fmt.Errorf("uuid: incorrect UUID format %s", t)
 	}
 
-	src := t[:]
+	src := t
 	dst := u[:]
 
 	for i, byteGroup := range byteGroups {


### PR DESCRIPTION
Drop unnecessary slice since type is already a slice.