### PR TITLE
Change (*UUID) Scan to accept type UUID argument

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -38,6 +38,10 @@ func (u UUID) Value() (driver.Value, error) {
 // a longer byte slice or a string will be handled by UnmarshalText.
 func (u *UUID) Scan(src interface{}) error {
 	switch src := src.(type) {
+	case UUID: // support gorm convert from UUID to NullUUID
+		*u = src
+		return nil
+
 	case []byte:
 		if len(src) == Size {
 			return u.UnmarshalBinary(src)

--- a/sql_test.go
+++ b/sql_test.go
@@ -118,6 +118,7 @@ func TestNullUUID(t *testing.T) {
 	t.Run("Scan", func(t *testing.T) {
 		t.Run("Nil", testNullUUIDScanNil)
 		t.Run("Valid", testNullUUIDScanValid)
+		t.Run("UUID", testNullUUIDScanUUID)
 	})
 
 	t.Run("MarshalJSON", func(t *testing.T) {
@@ -190,6 +191,20 @@ func testNullUUIDScanValid(t *testing.T) {
 	}
 	if u.UUID != codecTestUUID {
 		t.Errorf("UUID == %v after Scan(%q), want %v", u.UUID, s, codecTestUUID)
+	}
+}
+
+func testNullUUIDScanUUID(t *testing.T) {
+	u := NullUUID{}
+	err := u.Scan(codecTestUUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !u.Valid {
+		t.Errorf("Valid == false after scan(%v)", codecTestUUID)
+	}
+	if u.UUID != codecTestUUID {
+		t.Errorf("UUID == %v after Scan(%v), want %v", u.UUID, codecTestUUID, codecTestUUID)
 	}
 }
 


### PR DESCRIPTION
Type UUID can not used as primary key, which is not NULL in table. Type
NullUUID can be used as reference to the primary key in another table,
which may be NULL. If we use jinzhu/gorm to implement the usage
scenario, jinzhu/gorm convert UUID to NullUUID via NullUUID Scan
call. Without the fix below error may be found: uuid: cannot convert
uuid.UUID to UUID.

This fix changes (*UUID) scan to accept UUID argument.
