### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ package main
 import (
 	"log"
 
-	"github.com/gofrs/uuid/v3"
+        // if using modules you may want github.com/gofrs/uuid/v3 instead
+	"github.com/gofrs/uuid"
 )
 
 // Create a Version 4 UUID, panicking on error.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ package main
 import (
 	"log"
 
-	"github.com/gofrs/uuid"
+	"github.com/gofrs/uuid/v3"
 )
 
 // Create a Version 4 UUID, panicking on error.


### PR DESCRIPTION
add the correct canonical way of importing go modules that are greater than or equal to version 2