### PR TITLE
Use the latest Go releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: go
 sudo: false
 go:
-  - 1.7
-  - 1.8
-  - 1.9
-  - "1.10"
-  - 1.11
+  - 1.7.x
+  - 1.8.x
+  - 1.9.x
+  - 1.10.x
+  - 1.11.x
   - tip
 matrix:
   allow_failures:


### PR DESCRIPTION
Should we also drop support for older(pre 1.10) versions? 
They're not patched nor supported anymore.