### PR TITLE
Update V2 test to use delay to guarantee unique UUID generation

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -22,9 +22,9 @@
 package uuid
 
 import (
-	"crypto/md5"
+	"crypto/md5" // #nosec
 	"crypto/rand"
-	"crypto/sha1"
+	"crypto/sha1" // #nosec
 	"encoding/binary"
 	"fmt"
 	"hash"
@@ -165,6 +165,13 @@ func (g *Gen) NewV1() (UUID, error) {
 }
 
 // NewV2 returns a DCE Security UUID based on the POSIX UID/GID.
+//
+// Note: This UUID version has some limitations that generally make it
+// unsuitable for widespread use. Specifically, based on how internal fields are
+// used and structured, the generated UUID will only change once every 7
+// seconds. Most consumers of this package will want to use NewV4() instead.
+//
+// This package retains V2 support for compatibility reasons.
 func (g *Gen) NewV2(domain byte) (UUID, error) {
 	u, err := g.NewV1()
 	if err != nil {
@@ -188,7 +195,7 @@ func (g *Gen) NewV2(domain byte) (UUID, error) {
 
 // NewV3 returns a UUID based on the MD5 hash of the namespace UUID and name.
 func (g *Gen) NewV3(ns UUID, name string) UUID {
-	u := newFromHash(md5.New(), ns, name)
+	u := newFromHash(md5.New(), ns, name) // #nosec
 	u.SetVersion(V3)
 	u.SetVariant(VariantRFC4122)
 
@@ -209,7 +216,7 @@ func (g *Gen) NewV4() (UUID, error) {
 
 // NewV5 returns a UUID based on SHA-1 hash of the namespace UUID and name.
 func (g *Gen) NewV5(ns UUID, name string) UUID {
-	u := newFromHash(sha1.New(), ns, name)
+	u := newFromHash(sha1.New(), ns, name) // #nosec
 	u.SetVersion(V5)
 	u.SetVariant(VariantRFC4122)
 

--- a/generator_test.go
+++ b/generator_test.go
@@ -173,7 +173,7 @@ func testNewV1MissingNetworkFaultyRand(t *testing.T) {
 
 func testNewV2(t *testing.T) {
 	t.Run("Basic", testNewV2Basic)
-	t.Run("DifferentAcrossCalls", testNewV2DifferentAcrossCalls)
+	t.Run("DifferentAcrossCalls", testGenNewV2DifferentAcrossCalls)
 	t.Run("FaultyRand", testNewV2FaultyRand)
 }
 
@@ -197,15 +197,27 @@ func testNewV2Basic(t *testing.T) {
 	}
 }
 
-func testNewV2DifferentAcrossCalls(t *testing.T) {
-	u1, err := NewV2(DomainOrg)
+func testGenNewV2DifferentAcrossCalls(t *testing.T) {
+	start := time.Now()
+	calls := time.Duration(0)
+
+	g := NewGen()
+	g.epochFunc = func() time.Time {
+		t := start.Add(calls * 8 * time.Second)
+		calls++
+		return t
+	}
+
+	u1, err := g.NewV2(DomainOrg)
 	if err != nil {
 		t.Fatal(err)
 	}
-	u2, err := NewV2(DomainOrg)
+
+	u2, err := g.NewV2(DomainOrg)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if u1 == u2 {
 		t.Errorf("generated identical UUIDs across calls: %v", u1)
 	}


### PR DESCRIPTION
This change updates the uniqueness test for the `NewV2()` function to have a
time hop between the two generations of the UUID. This should avoid known
deficiencies in V2 UUIDs causing the test to fail. Specifically, that unique
UUIDs are only generated every 7 seconds.

This enhances the comment on the NewV2 function to make it clear that using it
is not recommended, and that it has some deficiencies.

Finally, I added some `#nosec` comments to make `gosec` not flag our usage of
SHA1 or MD5 as being unsafe.

Fixes #69

Signed-off-by: Tim Heckman <t@heckman.io>