### PR TITLE
module support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/gofrs/uuid/v3
+
+go 1.12


### PR DESCRIPTION
> I did not see any issues or PRs for module support, so I made one

Go has released [modules](https://github.com/golang/go/wiki/Modules) and while this repo does correctly tag releases, there is no `go.mod` file causing requires to look like `github.com/gofrs/uuid v3.2.0+incompatible`.

This change is backwards compatible, and should cause no breakage for existing customers.

After merge, a new tag should be pushed: `v3.2.1`.