### PR TITLE
Add Go 1.12 releases to the travic CI yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ go:
   - 1.9.x
   - 1.10.x
   - 1.11.x
+  - 1.12.x
   - tip
 matrix:
   allow_failures:


### PR DESCRIPTION
Add Go 1.12 to the build pipeline.