### PR TITLE
Remove GO111MODULE from travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ matrix:
   allow_failures:
     - go: tip
   fast_finish: true
-env:
-  - GO111MODULE=on
 before_install:
   - go get golang.org/x/tools/cmd/cover
 script:


### PR DESCRIPTION
Since uuid doesn't use go mods, this env var is unnecessary. go modules is set to work by default (without setting any env var) after 1.13.