### PR TITLE
improve codec error strings

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -114,7 +114,7 @@ func (u *UUID) UnmarshalText(text []byte) error {
 	case 41, 45:
 		return u.decodeURN(text)
 	default:
-		return fmt.Errorf("uuid: incorrect UUID length: %s", text)
+		return fmt.Errorf("uuid: incorrect UUID length %d in string %q", len(text), text)
 	}
 }
 
@@ -122,7 +122,7 @@ func (u *UUID) UnmarshalText(text []byte) error {
 // "6ba7b810-9dad-11d1-80b4-00c04fd430c8".
 func (u *UUID) decodeCanonical(t []byte) error {
 	if t[8] != '-' || t[13] != '-' || t[18] != '-' || t[23] != '-' {
-		return fmt.Errorf("uuid: incorrect UUID format %s", t)
+		return fmt.Errorf("uuid: incorrect UUID format in string %q", t)
 	}
 
 	src := t
@@ -160,7 +160,7 @@ func (u *UUID) decodeBraced(t []byte) error {
 	l := len(t)
 
 	if t[0] != '{' || t[l-1] != '}' {
-		return fmt.Errorf("uuid: incorrect UUID format %s", t)
+		return fmt.Errorf("uuid: incorrect UUID format in string %q", t)
 	}
 
 	return u.decodePlain(t[1 : l-1])
@@ -175,7 +175,7 @@ func (u *UUID) decodeURN(t []byte) error {
 	urnUUIDPrefix := t[:9]
 
 	if !bytes.Equal(urnUUIDPrefix, urnPrefix) {
-		return fmt.Errorf("uuid: incorrect UUID format: %s", t)
+		return fmt.Errorf("uuid: incorrect UUID format in string %q", t)
 	}
 
 	return u.decodePlain(t[9:total])
@@ -191,7 +191,7 @@ func (u *UUID) decodePlain(t []byte) error {
 	case 36:
 		return u.decodeCanonical(t)
 	default:
-		return fmt.Errorf("uuid: incorrect UUID length: %s", t)
+		return fmt.Errorf("uuid: incorrect UUID length %d in string %q", len(t), t)
 	}
 }
 


### PR DESCRIPTION
Right now, the invalid format error strings are confusing for attempts to parse empty strings, since they just end in a `length: `. It really looks like it should be printing the invalid length.

Furthermore, some of the errors use colons, and some of them don't, so even for the exact same error, the strings are inconsistent.

I propose to add single quotes around any `%s` verbs to make error messages more readable, as well as printing the erroneous length value and making colon usage consistent within `codec.go`