### PR TITLE
fixed version 2 domain bits to be spec compliant

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -178,7 +178,7 @@ func (g *Gen) NewV2(domain byte) (UUID, error) {
 		binary.BigEndian.PutUint32(u[:], posixGID)
 	}
 
-	u[9] = domain
+	u[8] = domain
 
 	u.SetVersion(V2)
 	u.SetVariant(VariantRFC4122)


### PR DESCRIPTION
I noticed some instability with testNewV2DifferentAcrossCalls. Wikipedia says "Version-2 UUIDs are similar to version 1, except that the least significant 8 bits of the clock sequence are replaced by a "local domain" number", which you're trying to do on line 181, except that you've generated the v1 UUID using binary.BigEndian. Big endian says that the "The most significant byte (MSB) value ... is at the lowest address. The other bytes follow in decreasing order of significance" (wikipedia again).

Since the clockSeq is inserted at [8:], assigning the domain to [9] was replacing the *most* significant bits (the ones most likely to change), not the least significant as specified. This patch fixes that. Not that anyone actually uses v2 in practice... but it's nice to have passing tests :)