### PR TITLE
Bump version to 420, enable Go modules support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/gofrs/uuid/v420
+
+go 1.15


### PR DESCRIPTION
The number was chosen as a reference to a peaceful community revolving around the use of an entheogen. This will make this package compliant with Go modules in the future.