### PR TITLE
stop using UnixMill() to make legacy versions compatible

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -285,7 +285,7 @@ func (g *Gen) NewV7() (UUID, error) {
 	}
 
 	tn := g.epochFunc()
-	ms := uint64(tn.UnixMilli())
+	ms := uint64(tn.Unix())*1e3 + uint64(tn.Nanosecond())/1e6
 	u[0] = byte(ms >> 40)
 	u[1] = byte(ms >> 32)
 	u[2] = byte(ms >> 24)


### PR DESCRIPTION
The following PR makes use of UnixMill() to get milli-precision timestamps.
https://github.com/gofrs/uuid/pull/99

UnixMill() was added in go1.17, so it seems that the latest gofrs/uuid is not available from older versions of go.

According to [Go's release policy](https://go.dev/doc/devel/release#policy), the last two versions of go are supported.
Therefore, I don't think it is a critical issue that it is not available for go versions older than go1.16.
However, since we expect some users to use older versions of go, we thought it would be better to stop using UnixMill().