### PR TITLE
all: gofmt with Go 1.19

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -139,37 +139,36 @@ func (u UUID) MarshalText() ([]byte, error) {
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 // Following formats are supported:
 //
-//   "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
-//   "{6ba7b810-9dad-11d1-80b4-00c04fd430c8}",
-//   "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8"
-//   "6ba7b8109dad11d180b400c04fd430c8"
-//   "{6ba7b8109dad11d180b400c04fd430c8}",
-//   "urn:uuid:6ba7b8109dad11d180b400c04fd430c8"
+//	"6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+//	"{6ba7b810-9dad-11d1-80b4-00c04fd430c8}",
+//	"urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+//	"6ba7b8109dad11d180b400c04fd430c8"
+//	"{6ba7b8109dad11d180b400c04fd430c8}",
+//	"urn:uuid:6ba7b8109dad11d180b400c04fd430c8"
 //
 // ABNF for supported UUID text representation follows:
 //
-//   URN := 'urn'
-//   UUID-NID := 'uuid'
+//	URN := 'urn'
+//	UUID-NID := 'uuid'
 //
-//   hexdig := '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' |
-//             'a' | 'b' | 'c' | 'd' | 'e' | 'f' |
-//             'A' | 'B' | 'C' | 'D' | 'E' | 'F'
+//	hexdig := '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' |
+//	          'a' | 'b' | 'c' | 'd' | 'e' | 'f' |
+//	          'A' | 'B' | 'C' | 'D' | 'E' | 'F'
 //
-//   hexoct := hexdig hexdig
-//   2hexoct := hexoct hexoct
-//   4hexoct := 2hexoct 2hexoct
-//   6hexoct := 4hexoct 2hexoct
-//   12hexoct := 6hexoct 6hexoct
+//	hexoct := hexdig hexdig
+//	2hexoct := hexoct hexoct
+//	4hexoct := 2hexoct 2hexoct
+//	6hexoct := 4hexoct 2hexoct
+//	12hexoct := 6hexoct 6hexoct
 //
-//   hashlike := 12hexoct
-//   canonical := 4hexoct '-' 2hexoct '-' 2hexoct '-' 6hexoct
+//	hashlike := 12hexoct
+//	canonical := 4hexoct '-' 2hexoct '-' 2hexoct '-' 6hexoct
 //
-//   plain := canonical | hashlike
-//   uuid := canonical | hashlike | braced | urn
+//	plain := canonical | hashlike
+//	uuid := canonical | hashlike | braced | urn
 //
-//   braced := '{' plain '}' | '{' hashlike  '}'
-//   urn := URN ':' UUID-NID ':' plain
-//
+//	braced := '{' plain '}' | '{' hashlike  '}'
+//	urn := URN ':' UUID-NID ':' plain
 func (u *UUID) UnmarshalText(b []byte) error {
 	switch len(b) {
 	case 32: // hash

--- a/fuzz.go
+++ b/fuzz.go
@@ -19,6 +19,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+//go:build gofuzz
 // +build gofuzz
 
 package uuid
@@ -27,15 +28,15 @@ package uuid
 //
 // To run:
 //
-//     $ go get github.com/dvyukov/go-fuzz/...
-//     $ cd $GOPATH/src/github.com/gofrs/uuid
-//     $ go-fuzz-build github.com/gofrs/uuid
-//     $ go-fuzz -bin=uuid-fuzz.zip -workdir=./testdata
+//	$ go get github.com/dvyukov/go-fuzz/...
+//	$ cd $GOPATH/src/github.com/gofrs/uuid
+//	$ go-fuzz-build github.com/gofrs/uuid
+//	$ go-fuzz -bin=uuid-fuzz.zip -workdir=./testdata
 //
 // If you make significant changes to FromString / UnmarshalText and add
 // new cases to fromStringTests (in codec_test.go), please run
 //
-//    $ go test -seed_fuzz_corpus
+//	$ go test -seed_fuzz_corpus
 //
 // to seed the corpus with the new interesting inputs, then run the fuzzer.
 func Fuzz(data []byte) int {

--- a/uuid.go
+++ b/uuid.go
@@ -275,7 +275,8 @@ func (u *UUID) SetVariant(v byte) {
 // Must is a helper that wraps a call to a function returning (UUID, error)
 // and panics if the error is non-nil. It is intended for use in variable
 // initializations such as
-//  var packageUUID = uuid.Must(uuid.FromString("123e4567-e89b-12d3-a456-426655440000"))
+//
+//	var packageUUID = uuid.Must(uuid.FromString("123e4567-e89b-12d3-a456-426655440000"))
 func Must(u UUID, err error) UUID {
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Go 1.19 adds doc comments. This commit runs `gofmt` on all the code to update the comments.

https://tip.golang.org/doc/go1.19#go-doc