### PR TITLE
Remove deprecated coverage pkg

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,9 +23,6 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
-    - name: Get Coverage
-      run:  go get golang.org/x/tools/cmd/cover
-
     - name: Build
       run: go build -v ./...
 


### PR DESCRIPTION
Recently I found that a previous change not related to workflows is failing  in my other PR https://github.com/gofrs/uuid/pull/111

It is happening because the package [golang.org/x/tools/cmd/cover](https://pkg.go.dev/golang.org/x/tools/cmd/cover) is no longer active and marked as deprecated, that's why the workflow will fail.


```
Run go get golang.org/x/tools/cmd/cover
  go get golang.org/x/tools/cmd/cover
  shell: /usr/bin/bash -e {0}
  env:
    GO111MODULE: auto
    GOROOT: /opt/hostedtoolcache/go/1.19.4/x64
cannot find package "golang.org/x/tools/cmd/cover" in any of:
	/opt/hostedtoolcache/go/1.19.4/x64/src/golang.org/x/tools/cmd/cover (from $GOROOT)
	/home/runner/go/src/golang.org/x/tools/cmd/cover (from $GOPATH)
Error: Process completed with exit code 1.
```
The tests are focused on 1.18 e 1.19  and no longer needs to install ` golang.org/x/tools/cmd/cover`