### PR TITLE
add gomod support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/gofrs/uuid/v5
+
+go 1.17


### PR DESCRIPTION
This PR adds gomod support as an alternate to #97, and implements #85.

In #97 , we discuss a proposal to fork the repo to stay perpetually at major version 0 so as to not force users to provide maintenance on their import paths. It's been a year since that proposal was opened and there's been no major steps have been made to move us to a different repo or incorporate modules. In the meantime, the go ecosystem has moved on to incorporate go.mod and it is increasingly making less sense for us to not comply with the standard package management for go.

Irrespective of the history this module has with go.mod (see notorious #61 and #65), the status quo has changed and consuming packages are no longer in flux with glide, dep, and gomod in a way that we need to support all at once. In this PR we take the appropriate cautious (potentially unnecessarily so) and incorporate gomodules as a major version increment in order to bypass strange problems with versioning.

To provide a complete proposal for merging this PR, here are some pros and cons.

Pros:
* This package is now in conformance to the official package management tool for the go ecosystem
* This resolves a perceived disincentive to adopt this library - the incompatibility with gomodules/
* This change is friendlier to users' development environments
* Gomod will help us enforce minimum supported versions of go

Cons:
* Users will need to include the major version in their import paths
* We need to be extra careful about unnecessary breaking changes
* We folded to 'the man' ;)

For the first con, consumers who are unhappy with this change should strongly consider wrapping their usage of `gofrs/uuid` in a UUID module so that they only have to update one import path when they upgrade this repository.

Additionally, for maintainers of this library, it is important for us to be aware of but not paralyzed by the impact of making breaking changes to the library. We have not made a breaking change in [2 years](https://github.com/gofrs/uuid/releases/tag/v4.0.0), and even though we're experimenting with v6 ad v7 UUIDs, there's nothing indicating that we are going to need to break the API anytime soon.

I'll leave this PR open for a week to collect feedback.