### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Supported Versions
 
 We support the latest version of this library. We do not guarantee support of previous versions. If a defect is reported, it will generally be fixed on the latest version 
-(provided it exists) irrespective of whether it was introduced to a prior version.
+(provided it exists) irrespective of whether it was introduced in a prior version.
 
 ## Reporting a Vulnerability
 
@@ -19,4 +19,4 @@ This project submits security [results](https://scorecard.dev/viewer/?uri=github
 
 One heuristic these scorecards measure to gauge whether a package is safe for consumption is an "Actively Maintained" metric. Because this library implements UUIDs,
 it is very stable - there is not much maintenance required other than adding/updating newer UUID versions, keeping up to date with latest versions of Go, and responding
-to reported exploits. As a result, periods of low active maintance are to be expected. 
+to reported exploits. As a result, periods of low active maintenance are to be expected. 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Supported Versions
+
+We support the latest version of this library. We do not guarantee support of previous versions. If a defect is reported, it will generally be fixed on the latest version 
+(provided it exists) irrespective of whether it was introduced to a prior version.
+
+## Reporting a Vulnerability
+
+If you discover a vulnerability against this package, please report it in the issues tab with a `vulnerability` label. We will examine promptly.
+
+If you would like to disclose the vulnerability privately, you may reach the maintainers in our [channel](https://gophers.slack.com/archives/CBP4N9BEU) on the gophers slack.
+
+## Security Scorecard
+
+This project submits security [results](https://scorecard.dev/viewer/?uri=github.com/gofrs/uuid) to the [OpenSSF Scorecard](https://securityscorecards.dev/). 
+
+### Actively Maintained
+
+One heuristic these scorecards measure to gauge whether a package is safe for consumption is an "Actively Maintained" metric. Because this library implements UUIDs,
+it is very stable - there is not much maintenance required other than adding/updating newer UUID versions, keeping up to date with latest versions of Go, and responding
+to reported exploits. As a result, periods of low active maintance are to be expected. 


### PR DESCRIPTION
This PR creates a security policy based off of recommendations from the OpenSSF Scorecard. 

A security policy may seem gratuitous, but its worthwhile to remember that this library was born from a security vulnerability on the repo from which it was forked, satori/go.uuid.  Our library is simple, but it doesn't mean its immune from vulnerabilities or security issues :)

With this security policy, we shoot for simplicity:

- Support latest, unless there's a very good reason to not. Our package is relatively easy to keep up to date, and we go through great pains to not break the API. As a result, we should be able to put forth an expectation of supporting latest.
- Lay out simple instructions for reporting a vulnerability
- Mention our cooperation with OpenSSF Scorecard, and make a nod to the fact that our actively maintained score may drop when there's just not much to do with the library.