### PR TITLE
chore: group GitHub Action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      all:
+        patterns:
+          - "*"  # Group all updates into a single larger pull request.
 
   - package-ecosystem: gomod
     directory: /


### PR DESCRIPTION
Adds a configuration for Dependabot to group all GitHub Action updates.