### PR TITLE
Proper timestamp calculation for UUID v7

### DIFF
--- a/generator_test.go
+++ b/generator_test.go
@@ -1101,7 +1101,6 @@ func TestDefaultHWAddrFunc(t *testing.T) {
 }
 
 func BenchmarkGenerator(b *testing.B) {
-	b.ReportAllocs()
 	b.Run("NewV1", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			NewV1()

--- a/generator_test.go
+++ b/generator_test.go
@@ -1101,6 +1101,7 @@ func TestDefaultHWAddrFunc(t *testing.T) {
 }
 
 func BenchmarkGenerator(b *testing.B) {
+	b.ReportAllocs()
 	b.Run("NewV1", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			NewV1()
@@ -1119,6 +1120,16 @@ func BenchmarkGenerator(b *testing.B) {
 	b.Run("NewV5", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			NewV5(NamespaceDNS, "www.example.com")
+		}
+	})
+	b.Run("NewV6", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			NewV6()
+		}
+	})
+	b.Run("NewV7", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			NewV7()
 		}
 	})
 }

--- a/uuid.go
+++ b/uuid.go
@@ -147,10 +147,10 @@ func TimestampFromV7(u UUID) (Timestamp, error) {
 		(int64(u[4]) << 8) |
 		int64(u[5])
 
-	// UUIDv7 stores MS since 1979-01-01 00:00:00, but the Timestamp
+	// UUIDv7 stores MS since 1970-01-01 00:00:00, but the Timestamp
 	// type stores 100-nanosecond increments since 1582-10-15 00:00:00.
 	// This conversion multiplies ms by 10,000 to get 100-ns chunks and adds
-	// the difference between October 1582 and January 1979.
+	// the difference between October 1582 and January 1970.
 	tsNanos := epochStart + (t * _100nsPerMillisecond)
 	return Timestamp(tsNanos), nil
 }

--- a/uuid.go
+++ b/uuid.go
@@ -89,7 +89,6 @@ const (
 type Timestamp uint64
 
 const _100nsPerSecond = 10000000
-const _100nsPerMillisecond = 10000
 
 // Time returns the time.Time representation of a Timestamp.
 //
@@ -151,7 +150,7 @@ func TimestampFromV7(u UUID) (Timestamp, error) {
 	// type stores 100-nanosecond increments since 1582-10-15 00:00:00.
 	// This conversion multiplies ms by 10,000 to get 100-ns chunks and adds
 	// the difference between October 1582 and January 1970.
-	tsNanos := epochStart + (t * _100nsPerMillisecond)
+	tsNanos := epochStart + (t * 10000)
 	return Timestamp(tsNanos), nil
 }
 

--- a/uuid.go
+++ b/uuid.go
@@ -82,8 +82,10 @@ const (
 )
 
 // Timestamp is the count of 100-nanosecond intervals since 00:00:00.00,
-// 15 October 1582 within a V1 UUID. This type has no meaning for other
-// UUID versions since they don't have an embedded timestamp.
+// 15 October 1582 within a V1 or V6 UUID, or as a common intermediate
+// representation of the (Unix Millisecond) timestamp within a V7 UUID.
+// This type has no meaning for other UUID versions since they don't
+// have an embedded timestamp.
 type Timestamp uint64
 
 const _100nsPerSecond = 10000000

--- a/uuid.go
+++ b/uuid.go
@@ -87,6 +87,7 @@ const (
 type Timestamp uint64
 
 const _100nsPerSecond = 10000000
+const _100nsPerMillisecond = 10000
 
 // Time returns the time.Time representation of a Timestamp.
 //
@@ -145,7 +146,7 @@ func TimestampFromV7(u UUID) (Timestamp, error) {
 		int64(u[5])
 
 	// convert to format expected by Timestamp
-	tsNanos := epochStart + time.UnixMilli(t).UTC().UnixNano()/100
+	tsNanos := epochStart + (t * _100nsPerMillisecond)
 	return Timestamp(tsNanos), nil
 }
 

--- a/uuid.go
+++ b/uuid.go
@@ -147,7 +147,10 @@ func TimestampFromV7(u UUID) (Timestamp, error) {
 		(int64(u[4]) << 8) |
 		int64(u[5])
 
-	// convert to format expected by Timestamp
+	// UUIDv7 stores MS since 1979-01-01 00:00:00, but the Timestamp
+	// type stores 100-nanosecond increments since 1582-10-15 00:00:00.
+	// This conversion multiplies ms by 10,000 to get 100-ns chunks and adds
+	// the difference between October 1582 and January 1979.
 	tsNanos := epochStart + (t * _100nsPerMillisecond)
 	return Timestamp(tsNanos), nil
 }

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -281,6 +281,56 @@ func TestTimestampFromV7(t *testing.T) {
 	}
 }
 
+func TestTimestampMinMaxV167(t *testing.T) {
+	tests := []struct {
+		u    UUID
+		want time.Time
+	}{
+
+		// v1 min and max
+		{u: Must(FromString("00000000-0000-1000-8000-000000000000")), want: time.Date(1582, 10, 15, 0, 0, 0, 0, time.UTC)},           //1582-10-15 0:00:00 (UTC)
+		{u: Must(FromString("ffffffff-ffff-1fff-bfff-ffffffffffff")), want: time.Date(5236, 3, 31, 21, 21, 00, 684697500, time.UTC)}, //5236-03-31 21:21:00 (UTC)
+
+		// v6 min and max
+		{u: Must(FromString("00000000-0000-6000-8000-000000000000")), want: time.Date(1582, 10, 15, 0, 0, 0, 0, time.UTC)},           //1582-10-15 0:00:00 (UTC)
+		{u: Must(FromString("ffffffff-ffff-6fff-bfff-ffffffffffff")), want: time.Date(5236, 3, 31, 21, 21, 00, 684697500, time.UTC)}, //5236-03-31 21:21:00 (UTC)
+
+		// v7 min and max
+		{u: Must(FromString("00000000-0000-7000-8000-000000000000")), want: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)},            //1970-01-01 0:00:00 (UTC)
+		{u: Must(FromString("ffffffff-ffff-7fff-bfff-ffffffffffff")), want: time.Date(10889, 8, 2, 5, 31, 50, 655000000, time.UTC)}, //10889-08-02 5:31:50.655 (UTC)
+	}
+	for _, tt := range tests {
+		var got Timestamp
+		var err error
+		var functionName string
+
+		switch tt.u.Version() {
+		case V1:
+			functionName = "TimestampFromV1"
+			got, err = TimestampFromV1(tt.u)
+		case V6:
+			functionName = "TimestampFromV6"
+			got, err = TimestampFromV6(tt.u)
+		case V7:
+			functionName = "TimestampFromV7"
+			got, err = TimestampFromV7(tt.u)
+		}
+
+		if err != nil {
+			t.Errorf(functionName+"(%v) got error %v, want %v", tt.u, err, tt.want)
+		}
+
+		tm, err := got.Time()
+		if err != nil {
+			t.Errorf(functionName+"(%v) got error %v, want %v", tt.u, err, tt.want)
+		}
+
+		if !tt.want.Equal(tm) {
+			t.Errorf(functionName+"(%v) got %v, want %v", tt.u, tm.UTC(), tt.want)
+		}
+	}
+}
+
 func BenchmarkFormat(b *testing.B) {
 	var tests = []string{
 		"%s",

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -262,11 +262,11 @@ func TestTimestampFromV7(t *testing.T) {
 		want    Timestamp
 		wanterr bool
 	}{
-		{u: Must(NewV1()), wanterr: true},
 		// v7 is unix_ts_ms, so zero value time is unix epoch
 		{u: Must(FromString("00000000-0000-7000-0000-000000000000")), want: 122192928000000000},
 		{u: Must(FromString("018a8fec-3ced-7164-995f-93c80cbdc575")), want: 139139245386050000},
-		{u: Must(FromString("ffffffff-ffff-7fff-ffff-ffffffffffff")), want: Timestamp(epochStart + time.UnixMilli((1<<48)-1).UTC().UnixNano()/100)},
+		// Calculated as `(1<<48)-1` milliseconds, times 100 ns per ms, plus epoch offset from 1970 to 1582.
+		{u: Must(FromString("ffffffff-ffff-7fff-bfff-ffffffffffff")), want: 2936942695106550000},
 	}
 	for _, tt := range tests {
 		got, err := TimestampFromV7(tt.u)

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -262,6 +262,9 @@ func TestTimestampFromV7(t *testing.T) {
 		want    Timestamp
 		wanterr bool
 	}{
+		// These non-V7 versions should not be able to be provided to TimestampFromV7
+		{u: Must(NewV1()), wanterr: true},
+		{u: NewV3(NamespaceDNS, "a.example.com"), wanterr: true},
 		// v7 is unix_ts_ms, so zero value time is unix epoch
 		{u: Must(FromString("00000000-0000-7000-0000-000000000000")), want: 122192928000000000},
 		{u: Must(FromString("018a8fec-3ced-7164-995f-93c80cbdc575")), want: 139139245386050000},

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -284,7 +284,7 @@ func TestTimestampFromV7(t *testing.T) {
 	}
 }
 
-func TestTimestampMinMaxV167(t *testing.T) {
+func TestMinMaxTimestamps(t *testing.T) {
 	tests := []struct {
 		u    UUID
 		want time.Time
@@ -359,8 +359,6 @@ var timestampBenchmarkSink Timestamp
 var timeBenchmarkSink time.Time
 
 func BenchmarkTimestampFrom(b *testing.B) {
-	b.ReportAllocs()
-
 	var err error
 	numbUUIDs := 1000
 	if testing.Short() {
@@ -400,8 +398,6 @@ func BenchmarkTimestampFrom(b *testing.B) {
 }
 
 func BenchmarkTimestampTime(b *testing.B) {
-	b.ReportAllocs()
-
 	var err error
 	numbUUIDs := 1000
 	if testing.Short() {


### PR DESCRIPTION
Fixes #195.

The use of the `time.Time` method `UnixNanos()` was causing an `int64` overflow (officially an "undefined behavior"), and returning incorrect timestamp values.

There wasn't any good reason for using this function, since the goal is to convert milliseconds to 100-nanosecond intervals, which can be done much more simply with a single multiplication step.

---

This might also provide a slight performance improvement (see https://github.com/gofrs/uuid/issues/128#issuecomment-2106517809), since `time.UnixMilli`, the (unneeded) call to `.UTC()`, and `.UnixNano()` are each doing a fair bit of work internally, and they have all been replaced with a single multiplication.