### PR TITLE
Improve performance of FromBytesOrNil

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -34,10 +34,15 @@ func FromBytes(input []byte) (UUID, error) {
 // FromBytesOrNil returns a UUID generated from the raw byte slice input.
 // Same behavior as FromBytes(), but returns uuid.Nil instead of an error.
 func FromBytesOrNil(input []byte) UUID {
-	uuid, err := FromBytes(input)
-	if err != nil {
+	// The logic here is duplicated from UnmarshalBinary as there is unnecessary
+	// overhead generating errors which would be checked and discarded.
+	if len(input) != Size {
 		return Nil
 	}
+
+	uuid := UUID{}
+	copy(uuid[:], input)
+
 	return uuid
 }
 

--- a/codec_test.go
+++ b/codec_test.go
@@ -342,6 +342,22 @@ func BenchmarkFromString(b *testing.B) {
 	})
 }
 
+var FromBytesOrNilResult UUID
+
+func BenchmarkFromBytesOrNil(b *testing.B) {
+	b.Run("valid", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			FromBytesOrNilResult = FromBytesOrNil(codecTestData)
+		}
+	})
+
+	b.Run("empty", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			FromBytesOrNilResult = FromBytesOrNil([]byte{})
+		}
+	})
+}
+
 func BenchmarkUnmarshalText(b *testing.B) {
 	b.Run("canonical", func(b *testing.B) {
 		text := []byte(Must(FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8")).String())


### PR DESCRIPTION
This pulls code from FromBytes and UnmarshalBinary into FromBytesOrNil which reduces the cost of creating a UUID from a byte slice. It also removes an allocation when the UUID is invalid as it no longer generates an error which is discarded. One downside of this approach is that it duplicates the logic from UnmarshalBinary.

```
goos: linux
goarch: amd64
pkg: github.com/gofrs/uuid/v5
cpu: AMD Ryzen 9 5950X 16-Core Processor
                        │    old.txt     │            new.txt            │
                        │     sec/op     │    sec/op     vs base         │
FromBytesOrNil/valid-32      3.814n ± 0%    1.118n ± 1%  -70.69% (n=100)
FromBytesOrNil/empty-32   135.3500n ± 0%   0.6514n ± 1%  -99.52% (n=100)
geomean                      22.72n        0.8534n       -96.24%

                        │   old.txt    │                 new.txt                  │
                        │     B/op     │    B/op     vs base                      │
FromBytesOrNil/valid-32   0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=100) ¹
FromBytesOrNil/empty-32   96.00 ± 0%      0.00 ± 0%  -100.00% (n=100)

                        │   old.txt    │                 new.txt                  │
                        │  allocs/op   │ allocs/op   vs base                      │
FromBytesOrNil/valid-32   0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=100) ¹
FromBytesOrNil/empty-32   2.000 ± 0%     0.000 ± 0%  -100.00% (n=100)
```

Benchmark for previous implementation
```
benchmark                            old ns/op     new ns/op     delta
BenchmarkFromBytesOrNil/valid-10     5.03          5.68          +12.82%
BenchmarkFromBytesOrNil/empty-10     114           2.04          -98.21%

benchmark                            old allocs     new allocs     delta
BenchmarkFromBytesOrNil/valid-10     0              0              +0.00%
BenchmarkFromBytesOrNil/empty-10     2              0              -100.00%

benchmark                            old bytes     new bytes     delta
BenchmarkFromBytesOrNil/valid-10     0             0             +0.00%
BenchmarkFromBytesOrNil/empty-10     96            0             -100.00%
```