### PR TITLE
Add package flag to change Value() return type to []byte

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -30,8 +30,22 @@ import (
 var _ driver.Valuer = UUID{}
 var _ sql.Scanner = (*UUID)(nil)
 
+// SQLEnableBinaryValue controls the format of the UUID returned by
+// UUID.Value().
+// By default, UUID.Value() returns the UUID as a string.
+// If SQLEnableBinaryValue is set to true, UUID.Value() returns
+// the UUID as a 16-byte slice.
+var SQLEnableBinaryValue = false
+
 // Value implements the driver.Valuer interface.
+// By default, it returns the UUID as a string.
+// If the package variable SQLEnableBinaryValue is set to true,
+// it returns the UUID as a 16-byte slice.
 func (u UUID) Value() (driver.Value, error) {
+	if SQLEnableBinaryValue {
+		return u.Bytes(), nil
+	}
+
 	return u.String(), nil
 }
 

--- a/sql_test.go
+++ b/sql_test.go
@@ -22,13 +22,17 @@
 package uuid
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"testing"
 )
 
 func TestSQL(t *testing.T) {
-	t.Run("Value", testSQLValue)
+	t.Run("Value", func(t *testing.T) {
+		t.Run("String", testSQLValueString)
+		t.Run("Binary", testSQLValueBinary)
+	})
 	t.Run("Scan", func(t *testing.T) {
 		t.Run("Binary", testSQLScanBinary)
 		t.Run("String", testSQLScanString)
@@ -38,7 +42,7 @@ func TestSQL(t *testing.T) {
 	})
 }
 
-func testSQLValue(t *testing.T) {
+func testSQLValueString(t *testing.T) {
 	v, err := codecTestUUID.Value()
 	if err != nil {
 		t.Fatal(err)
@@ -48,6 +52,24 @@ func testSQLValue(t *testing.T) {
 		t.Fatalf("Value() returned %T, want string", v)
 	}
 	if want := codecTestUUID.String(); got != want {
+		t.Errorf("Value() == %q, want %q", got, want)
+	}
+}
+
+func testSQLValueBinary(t *testing.T) {
+	SQLEnableBinaryValue = true
+	defer func() {
+		SQLEnableBinaryValue = false
+	}()
+	v, err := codecTestUUID.Value()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := v.([]byte)
+	if !ok {
+		t.Fatalf("Value() returned %T, want []byte", v)
+	}
+	if want := codecTestUUID.Bytes(); !bytes.Equal(got, want) {
 		t.Errorf("Value() == %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
This adds a package level toggle `SQLEnableBinaryValue` to change the behavior of `Value()` method.
Currently, the `Value()` implementation returns `String()` which causes problems when saving `UUID` to the database (e.g. MariaDB) which uses `BINARY(16)` for `UUID` representation. 
Example code:
```go
	_, err = db.Exec("CREATE TABLE IF NOT EXISTS test_uuid (uid BINARY(16) PRIMARY KEY)")
	if err != nil {
		panic(err)
	}

	uid, err := uuid.NewV7()
	if err != nil {
		panic(err)
	}

	_, err = db.Exec("INSERT INTO test_uuid (uid) VALUES (?)", uid)
	if err != nil {
		panic(err)
	}
```
```
panic: Error 1406 (22001): Data too long for column 'uid' at row 1
```

To circumvent this, the only way is to convert `UUID` to `[]byte` slice using `Bytes()` before passing it as an argument.
```go
	_, err = db.Exec("INSERT INTO test_uuid (uid) VALUES (?)", uid.Bytes())
	if err != nil {
		panic(err)
	}
```
This makes it easy to accidentally pass unconverted value which will later call `Value()`, turn it into a string, and cause an error.
This can also cause subtle bugs in `WHERE ... IN (...)` statements, where unconverted `UUID` will not match any row even if it exists.
```go
	_, err = db.Exec("INSERT INTO test_uuid (uid) VALUES (?)", uid.Bytes())
	if err != nil {
		panic(err)
	}

	rows, err := db.Query("SELECT * FROM test_uuid WHERE uid IN (?)", uid)
	if err != nil {
		panic(err)
	}
	defer rows.Close()

	var uuids []uuid.UUID
	for rows.Next() {
		var uid uuid.UUID
		if err := rows.Scan(&uid); err != nil {
			panic(err)
		}
		uuids = append(uuids, uid)
	}

	fmt.Println("Found UUIDs:", uuids)
```
```
Found UUIDs: []
```
The cleanest and most ergonomic way to solve these problem would be if it was possible to toggle in the package what type is returned from `Value()` method. Then, no conversions would be needed and `UUID` could be passed to queries as is.