### PR TITLE
Update the minimum supported Go version and modernize

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Build
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
-        go-version: '1.22.x'
+        go-version: '1.26.x'
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -45,7 +45,7 @@ jobs:
     - name: Build
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
-        go-version: '1.21.x'
+        go-version: '1.25.x'
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ and parsing of UUIDs in different formats.
 
 This package supports the following UUID versions:
 
-* Version 1, based on timestamp and MAC address
-* Version 3, based on MD5 hashing of a named value
-* Version 4, based on random numbers
-* Version 5, based on SHA-1 hashing of a named value
-* Version 6, a k-sortable id based on timestamp, and field-compatible with v1
-* Version 7, a k-sortable id based on timestamp
+- Version 1, based on timestamp and MAC address
+- Version 3, based on MD5 hashing of a named value
+- Version 4, based on random numbers
+- Version 5, based on SHA-1 hashing of a named value
+- Version 6, a k-sortable id based on timestamp, and field-compatible with v1
+- Version 7, a k-sortable id based on timestamp
 
 ## Project History
 
@@ -48,7 +48,7 @@ deficiencies.
 
 ## Requirements
 
-This package requires Go 1.19 or later
+This package requires Go 1.25 or later
 
 ## Usage
 
@@ -88,5 +88,5 @@ func main() {
 
 ## References
 
-* [RFC-9562](https://tools.ietf.org/html/rfc9562) (replaces RFC-4122)
-* [DCE 1.1: Authentication and Security Services](http://pubs.opengroup.org/onlinepubs/9696989899/chap5.htm#tagcjh_08_02_01_01)
+- [RFC-9562](https://tools.ietf.org/html/rfc9562) (replaces RFC-4122)
+- [DCE 1.1: Authentication and Security Services](http://pubs.opengroup.org/onlinepubs/9696989899/chap5.htm#tagcjh_08_02_01_01)

--- a/codec_test.go
+++ b/codec_test.go
@@ -313,31 +313,31 @@ func TestFromHexChar(t *testing.T) {
 var stringBenchmarkSink string
 
 func BenchmarkString(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		stringBenchmarkSink = codecTestUUID.String()
 	}
 }
 
 func BenchmarkFromBytes(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		FromBytes(codecTestData)
+	for range b.N {
+		_, _ = FromBytes(codecTestData)
 	}
 }
 
 func BenchmarkFromString(b *testing.B) {
 	b.Run("canonical", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+		for range b.N {
+			_, _ = FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 		}
 	})
 	b.Run("urn", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			FromString("urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+		for range b.N {
+			_, _ = FromString("urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 		}
 	})
 	b.Run("braced", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			FromString("{6ba7b810-9dad-11d1-80b4-00c04fd430c8}")
+		for range b.N {
+			_, _ = FromString("{6ba7b810-9dad-11d1-80b4-00c04fd430c8}")
 		}
 	})
 }
@@ -346,13 +346,13 @@ var FromBytesOrNilResult UUID
 
 func BenchmarkFromBytesOrNil(b *testing.B) {
 	b.Run("valid", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			FromBytesOrNilResult = FromBytesOrNil(codecTestData)
 		}
 	})
 
 	b.Run("empty", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			FromBytesOrNilResult = FromBytesOrNil([]byte{})
 		}
 	})
@@ -366,7 +366,7 @@ func BenchmarkUnmarshalText(b *testing.B) {
 			b.Fatal(err)
 		}
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = u.UnmarshalText(text)
 		}
 	})
@@ -377,7 +377,7 @@ func BenchmarkUnmarshalText(b *testing.B) {
 			b.Fatal(err)
 		}
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = u.UnmarshalText(text)
 		}
 	})
@@ -388,27 +388,27 @@ func BenchmarkUnmarshalText(b *testing.B) {
 			b.Fatal(err)
 		}
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = u.UnmarshalText(text)
 		}
 	})
 }
 
 func BenchmarkMarshalBinary(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		codecTestUUID.MarshalBinary()
+	for range b.N {
+		_, _ = codecTestUUID.MarshalBinary()
 	}
 }
 
 func BenchmarkMarshalText(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		codecTestUUID.MarshalText()
+	for range b.N {
+		_, _ = codecTestUUID.MarshalText()
 	}
 }
 
 func BenchmarkParseV4(b *testing.B) {
 	const text = "f52a747a-983f-45f7-90b5-e84d70f470dd"
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		var u UUID
 		if err := u.Parse(text); err != nil {
 			b.Fatal(err)

--- a/codec_test.go
+++ b/codec_test.go
@@ -46,7 +46,7 @@ func TestFromBytes(t *testing.T) {
 	})
 	t.Run("Invalid", func(t *testing.T) {
 		var short [][]byte
-		for i := 0; i < len(codecTestData); i++ {
+		for i := range codecTestData {
 			short = append(short, codecTestData[:i])
 		}
 		var long [][]byte
@@ -298,7 +298,7 @@ func TestFromHexChar(t *testing.T) {
 		for _, c := range []byte(hextable + strings.ToUpper(hextable)) {
 			skip[c] = true
 		}
-		for i := 0; i < 256; i++ {
+		for i := range 256 {
 			c := byte(i)
 			if !skip[c] {
 				v := fromHexChar(c)

--- a/generator_test.go
+++ b/generator_test.go
@@ -765,7 +765,7 @@ func makeTestNewV7Basic10000000() func(t *testing.T) {
 
 		g := NewGen()
 
-		for i := 0; i < 10000000; i++ {
+		for range 10000000 {
 			u, err := g.NewV7()
 			if err != nil {
 				t.Fatal(err)

--- a/generator_test.go
+++ b/generator_test.go
@@ -1103,32 +1103,32 @@ func TestDefaultHWAddrFunc(t *testing.T) {
 func BenchmarkGenerator(b *testing.B) {
 	b.Run("NewV1", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			NewV1()
+			_, _ = NewV1()
 		}
 	})
 	b.Run("NewV3", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			NewV3(NamespaceDNS, "www.example.com")
+			_ = NewV3(NamespaceDNS, "www.example.com")
 		}
 	})
 	b.Run("NewV4", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			NewV4()
+			_, _ = NewV4()
 		}
 	})
 	b.Run("NewV5", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			NewV5(NamespaceDNS, "www.example.com")
+			_ = NewV5(NamespaceDNS, "www.example.com")
 		}
 	})
 	b.Run("NewV6", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			NewV6()
+			_, _ = NewV6()
 		}
 	})
 	b.Run("NewV7", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			NewV7()
+			_, _ = NewV7()
 		}
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/gofrs/uuid/v5
 
-go 1.19
+go 1.25

--- a/sql.go
+++ b/sql.go
@@ -38,7 +38,7 @@ func (u UUID) Value() (driver.Value, error) {
 // Scan implements the sql.Scanner interface.
 // A 16-byte slice will be handled by UnmarshalBinary, while
 // a longer byte slice or a string will be handled by UnmarshalText.
-func (u *UUID) Scan(src interface{}) error {
+func (u *UUID) Scan(src any) error {
 	switch src := src.(type) {
 	case UUID: // support gorm convert from UUID to NullUUID
 		*u = src
@@ -76,7 +76,7 @@ func (u NullUUID) Value() (driver.Value, error) {
 }
 
 // Scan implements the sql.Scanner interface.
-func (u *NullUUID) Scan(src interface{}) error {
+func (u *NullUUID) Scan(src any) error {
 	if src == nil {
 		u.UUID, u.Valid = Nil, false
 		return nil

--- a/sql_test.go
+++ b/sql_test.go
@@ -328,13 +328,13 @@ func BenchmarkNullMarshalJSON(b *testing.B) {
 		}
 		n := NullUUID{UUID: u, Valid: true}
 		for i := 0; i < b.N; i++ {
-			n.MarshalJSON()
+			_, _ = n.MarshalJSON()
 		}
 	})
 	b.Run("Invalid", func(b *testing.B) {
 		n := NullUUID{Valid: false}
 		for i := 0; i < b.N; i++ {
-			n.MarshalJSON()
+			_, _ = n.MarshalJSON()
 		}
 	})
 }
@@ -352,14 +352,14 @@ func BenchmarkNullUnmarshalJSON(b *testing.B) {
 	b.Run("Valid", func(b *testing.B) {
 		var u NullUUID
 		for i := 0; i < b.N; i++ {
-			u.UnmarshalJSON(data)
+			_ = u.UnmarshalJSON(data)
 		}
 	})
 	b.Run("Invalid", func(b *testing.B) {
 		invalid := []byte("null")
 		var n NullUUID
 		for i := 0; i < b.N; i++ {
-			n.UnmarshalJSON(invalid)
+			_ = n.UnmarshalJSON(invalid)
 		}
 	})
 }

--- a/sql_test.go
+++ b/sql_test.go
@@ -88,7 +88,7 @@ func testSQLScanText(t *testing.T) {
 }
 
 func testSQLScanUnsupported(t *testing.T) {
-	unsupported := []interface{}{
+	unsupported := []any{
 		true,
 		42,
 	}

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -373,7 +373,6 @@ func BenchmarkFormat(b *testing.B) {
 	}
 }
 
-var uuidBenchmarkSink UUID
 var timestampBenchmarkSink Timestamp
 var timeBenchmarkSink time.Time
 


### PR DESCRIPTION
- Updated the Go version in `go.mod` from 1.19 to 1.25
- Ran `go fix ./...` to apply modernizations
    - `interface{}`->`any`
    - `for`/`range` instead of 3-clause `for`
- Fix linter warnings in benchmarks about unused variables and unchecked errors