### PR TITLE
perf: Improve error handling performance by removing expensive formatting

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -21,8 +21,6 @@
 
 package uuid
 
-import "fmt"
-
 // FromBytes returns a UUID generated from the raw byte slice input.
 // It will return an error if the slice isn't 16 bytes long.
 func FromBytes(input []byte) (UUID, error) {
@@ -73,22 +71,22 @@ func parseBytes(b []byte, u *UUID) error {
 	case 36: // canonical
 	case 34, 38:
 		if b[0] != '{' || b[len(b)-1] != '}' {
-			return fmt.Errorf("%w %q", ErrIncorrectFormatInString, b)
+			return ErrInvalidBraces
 		}
 		b = b[1 : len(b)-1]
 	case 41, 45:
 		if string(b[:9]) != "urn:uuid:" {
-			return fmt.Errorf("%w %q", ErrIncorrectFormatInString, b[:9])
+			return ErrInvalidURNPrefix
 		}
 		b = b[9:]
 	default:
-		return fmt.Errorf("%w %d in string %q", ErrIncorrectLength, len(b), b)
+		return ErrIncorrectLength
 	}
 
 	// canonical (36 chars with dashes at fixed positions)
 	if len(b) == 36 {
 		if b[8] != '-' || b[13] != '-' || b[18] != '-' || b[23] != '-' {
-			return fmt.Errorf("%w %q", ErrIncorrectFormatInString, b)
+			return ErrInvalidDashes
 		}
 		for i, x := range [16]byte{
 			0, 2, 4, 6,
@@ -198,7 +196,7 @@ func (u UUID) MarshalBinary() ([]byte, error) {
 // It will return an error if the slice isn't 16 bytes long.
 func (u *UUID) UnmarshalBinary(data []byte) error {
 	if len(data) != Size {
-		return fmt.Errorf("%w, got %d bytes", ErrIncorrectByteLength, len(data))
+		return ErrIncorrectByteLength
 	}
 	copy(u[:], data)
 

--- a/error.go
+++ b/error.go
@@ -1,5 +1,7 @@
 package uuid
 
+import "fmt"
+
 // Error is a custom error type for UUID-related errors
 type Error string
 
@@ -32,6 +34,19 @@ const (
 
 	// ErrInvalidVersion indicates an unsupported or invalid UUID version.
 	ErrInvalidVersion = Error("uuid:")
+)
+
+// Wrapped errors for backward compatibility. These wrap ErrIncorrectFormatInString
+// so code like errors.Is(err, uuid.ErrIncorrectFormatInString) continues to work.
+var (
+	// ErrInvalidBraces is returned when braced format has invalid braces.
+	ErrInvalidBraces = fmt.Errorf("%w: invalid braces", ErrIncorrectFormatInString)
+
+	// ErrInvalidURNPrefix is returned when URN format has invalid prefix.
+	ErrInvalidURNPrefix = fmt.Errorf("%w: invalid URN prefix", ErrIncorrectFormatInString)
+
+	// ErrInvalidDashes is returned when canonical format has dashes not in expected positions.
+	ErrInvalidDashes = fmt.Errorf("%w: dashes were not in expected positions", ErrIncorrectFormatInString)
 )
 
 // Error returns the string representation of the UUID error.

--- a/error_test.go
+++ b/error_test.go
@@ -51,25 +51,25 @@ func TestParseErrors(t *testing.T) {
 		uuidStr  string
 		expected string
 	}{
-		{ // 34 chars - With brackets
+		{ // 34 chars - With braces
 			function: "parse",
 			uuidStr:  "..................................",
-			expected: "uuid: incorrect UUID format in string \"..................................\"",
+			expected: "uuid: incorrect UUID format in string: invalid braces",
 		},
 		{ // 41 chars - urn:uuid:
 			function: "parse",
 			uuidStr:  "123456789................................",
-			expected: "uuid: incorrect UUID format in string \"123456789\"",
+			expected: "uuid: incorrect UUID format in string: invalid URN prefix",
 		},
 		{ // other
 			function: "parse",
 			uuidStr:  "....",
-			expected: "uuid: incorrect UUID length 4 in string \"....\"",
+			expected: "uuid: incorrect UUID length",
 		},
 		{ // 36 chars - canonical, but not correct format
 			function: "parse",
 			uuidStr:  "....................................",
-			expected: "uuid: incorrect UUID format in string \"....................................\"",
+			expected: "uuid: incorrect UUID format in string: dashes were not in expected positions",
 		},
 		{ // 36 chars - canonical, invalid data
 			function: "parse",
@@ -118,7 +118,7 @@ func TestParseErrors(t *testing.T) {
 func TestUnmarshalBinaryError(t *testing.T) {
 	id := UUID{}
 	b := make([]byte, 33)
-	expectedErr := "uuid: UUID must be exactly 16 bytes long, got 33 bytes"
+	expectedErr := "uuid: UUID must be exactly 16 bytes long"
 	err := id.UnmarshalBinary([]byte(b))
 	if err == nil {
 		t.Error("expected an error")


### PR DESCRIPTION
Replace fmt.Errorf calls with lightweight error literals to improve parsing performance, following the same approach as Google's UUID library.

We noticed a difference in performance between the Google uuid library and gofrs for uuid parse failures. Wanted to raise this diff to ask why not just return simpler error messages. 