### PR TITLE
fix: prevent UUIDv7 counter wrap after 4096 ids

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -121,10 +121,10 @@ func NewV7() (UUID, error) {
 // 12-bit monotonic counter in rand_a, as described by RFC 9562 section 6.2,
 // Method 1.
 //
-// The provided timestamp is encoded as given, so unlike NewV7 the ordering
-// guarantee only holds for timestamps that do not move backwards. Timestamps
-// that repeat or advance behave as they do for NewV7, including the timestamp
-// being incremented ahead of the provided one once the counter is exhausted.
+// The provided timestamp is used as the starting point for generation, so unlike
+// NewV7 the ordering guarantee only holds for timestamps that do not move
+// backwards. Timestamps that repeat or advance behave as they do for NewV7,
+// including the embedded timestamp being incremented once the counter is exhausted.
 // Providing a timestamp ahead of the clock therefore holds later NewV7 UUIDs at
 // that timestamp, since going back below it would break their ordering. Times
 // outside the range the 48-bit millisecond field can represent are pinned to the

--- a/generator.go
+++ b/generator.go
@@ -37,6 +37,20 @@ import (
 // UUID epoch (October 15, 1582) and Unix epoch (January 1, 1970).
 const epochStart = 122192928000000000
 
+// V7 carries its monotonic counter in rand_a, the 12 bits sitting between the
+// version nibble and the variant.
+const maxV7Counter = 0x0fff
+
+// V7 timestamps are an unsigned 48 bit count of milliseconds since the Unix
+// epoch, a range that runs from 1970 into the year 10889.
+const maxV7Timestamp = 1<<48 - 1
+
+// The counter is seeded with 11 random bits at the start of every timestamp
+// tick, as described by RFC 9562 section 6.2 under "Fixed Bit-Length Dedicated
+// Counter Seeding". The leading bit is left zero to act as a rollover guard, so
+// at least 2048 increments are always available within a tick.
+const v7CounterSeedMask = 0x07ff
+
 // EpochFunc is the function type used to provide the current time.
 type EpochFunc func() time.Time
 
@@ -87,14 +101,34 @@ func NewV6AtTime(atTime time.Time) (UUID, error) {
 
 // NewV7 returns a k-sortable UUID based on the current millisecond-precision
 // UNIX epoch and 74 bits of pseudorandom data. It supports single-node batch
-// generation (multiple UUIDs in the same timestamp) with a Monotonic Random counter.
+// generation (multiple UUIDs in the same timestamp) with a 12-bit monotonic
+// counter in rand_a, as described by RFC 9562 section 6.2, Method 1.
+//
+// UUIDs returned by a single generator are strictly increasing: each one sorts
+// above the one before it, even within a millisecond and even if the system
+// clock moves backwards. The counter is reseeded with each millisecond, leaving
+// room for at least 2048 UUIDs within that millisecond. Beyond that the
+// embedded timestamp is incremented ahead of the actual time, so generating
+// UUIDs faster than roughly two million per second trades timestamp accuracy
+// for ordering.
 func NewV7() (UUID, error) {
 	return DefaultGenerator.NewV7()
 }
 
-// NewV7 returns a k-sortable UUID based on the provided millisecond-precision
-// UNIX epoch and 74 bits of pseudorandom data. It supports single-node batch
-// generation (multiple UUIDs in the same timestamp) with a Monotonic Random counter.
+// NewV7AtTime returns a k-sortable UUID based on the provided
+// millisecond-precision UNIX epoch and 74 bits of pseudorandom data. It supports
+// single-node batch generation (multiple UUIDs in the same timestamp) with a
+// 12-bit monotonic counter in rand_a, as described by RFC 9562 section 6.2,
+// Method 1.
+//
+// The provided timestamp is encoded as given, so unlike NewV7 the ordering
+// guarantee only holds for timestamps that do not move backwards. Timestamps
+// that repeat or advance behave as they do for NewV7, including the timestamp
+// being incremented ahead of the provided one once the counter is exhausted.
+// Providing a timestamp ahead of the clock therefore holds later NewV7 UUIDs at
+// that timestamp, since going back below it would break their ordering. Times
+// outside the range the 48-bit millisecond field can represent are pinned to the
+// nearest end of it.
 func NewV7AtTime(atTime time.Time) (UUID, error) {
 	return DefaultGenerator.NewV7AtTime(atTime)
 }
@@ -148,6 +182,14 @@ type Gen struct {
 	lastTime      uint64
 	clockSequence uint16
 	hardwareAddr  [6]byte
+
+	// V7 keeps its own counter state, separate from the V1/V6 clock sequence:
+	// the two measure time in different units and the counters have different
+	// usable widths.
+	v7LastRequestedMs uint64
+	v7LastMs          uint64
+	v7Counter         uint16
+	v7Seeded          bool
 }
 
 // GenOption is a function type that can be used to configure a Gen generator.
@@ -254,7 +296,7 @@ func (g *Gen) NewV1() (UUID, error) {
 func (g *Gen) NewV1AtTime(atTime time.Time) (UUID, error) {
 	u := UUID{}
 
-	timeNow, clockSeq, err := g.getClockSequence(false, atTime)
+	timeNow, clockSeq, err := g.getClockSequence(atTime)
 	if err != nil {
 		return Nil, err
 	}
@@ -338,7 +380,7 @@ func (g *Gen) NewV6AtTime(atTime time.Time) (UUID, error) {
 	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ */
 	var u UUID
 
-	timeNow, _, err := g.getClockSequence(false, atTime)
+	timeNow, _, err := g.getClockSequence(atTime)
 	if err != nil {
 		return Nil, err
 	}
@@ -363,14 +405,27 @@ func (g *Gen) NewV6AtTime(atTime time.Time) (UUID, error) {
 }
 
 // NewV7 returns a k-sortable UUID based on the current millisecond-precision
-// UNIX epoch and 74 bits of pseudorandom data.
+// UNIX epoch and 74 bits of pseudorandom data. UUIDs returned by a single
+// generator are strictly increasing; see the package-level NewV7 for the
+// details of that guarantee.
 func (g *Gen) NewV7() (UUID, error) {
-	return g.NewV7AtTime(g.epochFunc())
+	return g.newV7(g.epochFunc(), true)
 }
 
-// NewV7 returns a k-sortable UUID based on the provided millisecond-precision
-// UNIX epoch and 74 bits of pseudorandom data.
+// NewV7AtTime returns a k-sortable UUID based on the provided
+// millisecond-precision UNIX epoch and 74 bits of pseudorandom data. See the
+// package-level NewV7AtTime for how the provided timestamp interacts with the
+// monotonic counter.
 func (g *Gen) NewV7AtTime(atTime time.Time) (UUID, error) {
+	return g.newV7(atTime, false)
+}
+
+// newV7 builds a V7 UUID for atTime. When clampBackwards is set, a timestamp
+// older than the last one seen is replaced by that last timestamp so a
+// backwards-moving clock cannot produce out-of-order UUIDs. Callers that pass a
+// timestamp explicitly leave it unset, so that a deliberately older timestamp is
+// encoded as given.
+func (g *Gen) newV7(atTime time.Time, clampBackwards bool) (UUID, error) {
 	var u UUID
 	/* https://datatracker.ietf.org/doc/html/rfc9562#name-uuid-version-7
 	    0                   1                   2                   3
@@ -385,7 +440,12 @@ func (g *Gen) NewV7AtTime(atTime time.Time) (UUID, error) {
 	   |                            rand_b                             |
 	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ */
 
-	ms, clockSeq, err := g.getClockSequence(true, atTime)
+	// A time outside the range the timestamp field can hold has no
+	// representation, so the nearest end of that range stands in for it rather
+	// than the unrelated value the field would otherwise wrap to.
+	atMs := min(uint64(max(atTime.UnixMilli(), 0)), maxV7Timestamp)
+
+	ms, counter, err := g.nextV7Sequence(atMs, clampBackwards)
 	if err != nil {
 		return Nil, err
 	}
@@ -397,12 +457,11 @@ func (g *Gen) NewV7AtTime(atTime time.Time) (UUID, error) {
 	u[4] = byte(ms >> 8)
 	u[5] = byte(ms)
 
-	//Support batching by using a monotonic pseudo-random sequence,
+	//Support batching by using a dedicated counter in rand_a,
 	//as described in RFC 9562 section 6.2, Method 1.
-	//The 6th byte contains the version and partially rand_a data.
-	//We will lose the most significant bites from the clockSeq (with SetVersion), but it is ok,
-	//we need the least significant that contains the counter to ensure the monotonic property
-	binary.BigEndian.PutUint16(u[6:8], clockSeq) // set rand_a with clock seq which is random and monotonic
+	//The 6th byte contains the version and the top 4 bits of rand_a, so the
+	//counter is 12 bits wide and fits entirely below the version nibble.
+	binary.BigEndian.PutUint16(u[6:8], counter) // set rand_a with the monotonic counter
 
 	//override first 4bits of u[6].
 	u.SetVersion(V7)
@@ -462,13 +521,70 @@ func (g *Gen) NewV8(customA []byte, customB []byte, customC []byte) (UUID, error
 	return u, nil
 }
 
-// getClockSequence returns the epoch and clock sequence of the provided time,
-// used for generating V1,V6 and V7 UUIDs.
+// nextV7Sequence returns the millisecond timestamp and the 12-bit counter to
+// encode into a V7 UUID. The pair strictly increases from one call to the next,
+// which is what makes the resulting UUIDs sortable in generation order.
 //
-// When useUnixTSMs is false, it uses the Coordinated Universal Time (UTC) as a count of
-// 100-nanosecond intervals since 00:00:00.00, 15 October 1582 (the date of Gregorian
-// reform to the Christian calendar).
-func (g *Gen) getClockSequence(useUnixTSMs bool, atTime time.Time) (uint64, uint16, error) {
+// The counter is reseeded whenever the timestamp ticks over and incremented
+// otherwise. Once it runs out of room within a tick, the timestamp is
+// incremented ahead of the actual time and the counter reseeded, one of the two
+// rollover strategies allowed by RFC 9562 section 6.2. The alternative, waiting
+// for the clock to catch up, is not open to us: the timestamp can be supplied by
+// the caller and is then under no obligation to advance.
+func (g *Gen) nextV7Sequence(ms uint64, clampBackwards bool) (uint64, uint16, error) {
+	g.storageMutex.Lock()
+	defer g.storageMutex.Unlock()
+
+	// The counter starts over on a new tick. A provided timestamp that predates
+	// the one provided last also starts it over, since that is a request for an
+	// older UUID rather than a clock to be corrected for. The comparison for a
+	// new tick is against the timestamp last encoded, which a rollover may have
+	// pushed ahead of the one last provided.
+	if !g.v7Seeded || ms > g.v7LastMs || (!clampBackwards && ms < g.v7LastRequestedMs) {
+		counter, err := g.seedV7Counter()
+		if err != nil {
+			return 0, 0, err
+		}
+		g.v7Seeded = true
+		g.v7LastMs, g.v7LastRequestedMs, g.v7Counter = ms, ms, counter
+
+		return ms, counter, nil
+	}
+
+	// Still within the tick last encoded, either because the timestamp repeats
+	// or because it moved backwards and is being held at the last value.
+	if g.v7Counter >= maxV7Counter {
+		counter, err := g.seedV7Counter()
+		if err != nil {
+			return 0, 0, err
+		}
+		g.v7LastMs, g.v7Counter = g.v7LastMs+1, counter
+	} else {
+		g.v7Counter++
+	}
+	g.v7LastRequestedMs = ms
+
+	return g.v7LastMs, g.v7Counter, nil
+}
+
+// seedV7Counter draws a fresh value for the start of a timestamp tick, leaving
+// the counter's leading bit clear as a rollover guard.
+func (g *Gen) seedV7Counter() (uint16, error) {
+	var buf [2]byte
+	if _, err := io.ReadFull(g.rand, buf[:]); err != nil {
+		return 0, err
+	}
+
+	return binary.BigEndian.Uint16(buf[:]) & v7CounterSeedMask, nil
+}
+
+// getClockSequence returns the epoch and clock sequence of the provided time,
+// used for generating V1 and V6 UUIDs.
+//
+// The epoch is the Coordinated Universal Time (UTC) as a count of 100-nanosecond
+// intervals since 00:00:00.00, 15 October 1582 (the date of Gregorian reform to
+// the Christian calendar).
+func (g *Gen) getClockSequence(atTime time.Time) (uint64, uint16, error) {
 	var err error
 	g.clockSequenceOnce.Do(func() {
 		buf := make([]byte, 2)
@@ -484,12 +600,7 @@ func (g *Gen) getClockSequence(useUnixTSMs bool, atTime time.Time) (uint64, uint
 	g.storageMutex.Lock()
 	defer g.storageMutex.Unlock()
 
-	var timeNow uint64
-	if useUnixTSMs {
-		timeNow = uint64(atTime.UnixMilli())
-	} else {
-		timeNow = g.getEpoch(atTime)
-	}
+	timeNow := g.getEpoch(atTime)
 	// Clock didn't change since last UUID generation.
 	// Should increase clock sequence.
 	if timeNow <= g.lastTime {

--- a/generator_test.go
+++ b/generator_test.go
@@ -700,7 +700,7 @@ func testNewV6AtTime(t *testing.T) {
 func testNewV7(t *testing.T) {
 	t.Run("Basic", makeTestNewV7Basic())
 	t.Run("TestVector", makeTestNewV7TestVector())
-	t.Run("Basic10000000", makeTestNewV7Basic10000000())
+	t.Run("Basic10M", makeTestNewV7Basic10M())
 	t.Run("DifferentAcrossCalls", makeTestNewV7DifferentAcrossCalls())
 	t.Run("StaleEpoch", makeTestNewV7StaleEpoch())
 	t.Run("StaleEpochWithOptions", makeTestNewV7StaleEpochWithOptions())
@@ -711,7 +711,7 @@ func testNewV7(t *testing.T) {
 	t.Run("KSortable", makeTestNewV7KSortable())
 	t.Run("ClockSequence", makeTestNewV7ClockSequence())
 	t.Run("CounterRollover", makeTestNewV7CounterRollover())
-	t.Run("Sequential1000000", makeTestNewV7Sequential1000000())
+	t.Run("Sequential1M", makeTestNewV7Sequential1M())
 	t.Run("BorrowIsBounded", makeTestNewV7BorrowIsBounded())
 	t.Run("CounterReseedsOnNewTick", makeTestNewV7CounterReseedsOnNewTick())
 	t.Run("MixedWithV1", makeTestNewV7MixedWithV1())
@@ -789,7 +789,7 @@ func makeTestNewV7TestVector() func(t *testing.T) {
 	}
 }
 
-func makeTestNewV7Basic10000000() func(t *testing.T) {
+func makeTestNewV7Basic10M() func(t *testing.T) {
 	return func(t *testing.T) {
 		if testing.Short() {
 			t.Skip("skipping test in short mode.")
@@ -797,7 +797,7 @@ func makeTestNewV7Basic10000000() func(t *testing.T) {
 
 		g := NewGen()
 
-		for range 10000000 {
+		for range 10_000_000 {
 			u, err := g.NewV7()
 			if err != nil {
 				t.Fatal(err)
@@ -1008,13 +1008,13 @@ func makeTestNewV7CounterRollover() func(t *testing.T) {
 	}
 }
 
-// makeTestNewV7Sequential1000000 is the ordering check at load, against the real
+// makeTestNewV7Sequential1M is the ordering check at load, against the real
 // clock so that counter rollovers, the reseeding that follows them and the clock
 // advancing on its own all interleave. Sorting strictly above the previous UUID
 // also means differing from it, so this covers uniqueness across the run. UUIDs
 // are compared as they are generated rather than collected first, to keep the
 // count free to grow.
-func makeTestNewV7Sequential1000000() func(t *testing.T) {
+func makeTestNewV7Sequential1M() func(t *testing.T) {
 	return func(t *testing.T) {
 		if testing.Short() {
 			t.Skip("skipping test in short mode.")
@@ -1023,7 +1023,7 @@ func makeTestNewV7Sequential1000000() func(t *testing.T) {
 		g := NewGen()
 
 		var prev string
-		for i := range 1000000 {
+		for i := range 1_000_000 {
 			u, err := g.NewV7()
 			testErrCheck(t, "NewV7()", "", err)
 

--- a/generator_test.go
+++ b/generator_test.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -709,7 +710,35 @@ func testNewV7(t *testing.T) {
 	t.Run("ShortRandomReadWithOptions", makeTestNewV7ShortRandomReadWithOptions())
 	t.Run("KSortable", makeTestNewV7KSortable())
 	t.Run("ClockSequence", makeTestNewV7ClockSequence())
+	t.Run("CounterRollover", makeTestNewV7CounterRollover())
+	t.Run("BorrowIsBounded", makeTestNewV7BorrowIsBounded())
+	t.Run("CounterReseedsOnNewTick", makeTestNewV7CounterReseedsOnNewTick())
+	t.Run("MixedWithV1", makeTestNewV7MixedWithV1())
+	t.Run("BackwardsClock", makeTestNewV7BackwardsClock())
+	t.Run("AtTimeHistorical", makeTestNewV7AtTimeHistorical())
+	t.Run("AtTimeUnrepresentable", makeTestNewV7AtTimeUnrepresentable())
+	t.Run("Concurrent", makeTestNewV7Concurrent())
+	t.Run("FaultyRandOnReseed", makeTestNewV7FaultyRandOnReseed())
+	t.Run("FaultyRandOnRollover", makeTestNewV7FaultyRandOnRollover())
 	t.Run("AtSpecificTime", makeTestNewV7AtTime())
+}
+
+// v7Counter returns the 12 bits of rand_a that hold the monotonic counter.
+func v7Counter(u UUID) uint16 {
+	return binary.BigEndian.Uint16(u[6:8]) & maxV7Counter
+}
+
+// assertV7Increasing fails on the first UUID that does not sort above its
+// predecessor. A single generator should never produce one.
+func assertV7Increasing(t *testing.T, uuids []UUID) {
+	t.Helper()
+
+	for i := 1; i < len(uuids); i++ {
+		p, n := uuids[i-1], uuids[i]
+		if p.String() >= n.String() {
+			t.Fatalf("uuids[%d] (%s) not less than uuids[%d] (%s)", i-1, p, i, n)
+		}
+	}
 }
 
 func makeTestNewV7Basic() func(t *testing.T) {
@@ -731,7 +760,7 @@ func makeTestNewV7Basic() func(t *testing.T) {
 func makeTestNewV7TestVector() func(t *testing.T) {
 	return func(t *testing.T) {
 		pRand := make([]byte, 10)
-		//first 2 bytes will be read by clockSeq. First 4 bits will be overridden by Version. The next bits should be 0xCC3(3267)
+		//first 2 bytes will be read to seed the counter. First 4 bits will be overridden by Version. The next bits should be 0xCC3(3267)
 		binary.LittleEndian.PutUint16(pRand[:2], uint16(0xCC3))
 		//8bytes will be read for rand_b. First 2 bits will be overridden by Variant
 		binary.LittleEndian.PutUint64(pRand[2:], uint64(0x18C4DC0C0C07398F))
@@ -939,20 +968,430 @@ func makeTestNewV7ClockSequence() func(t *testing.T) {
 		g.epochFunc = func() time.Time {
 			return time.UnixMilli(1645557742000)
 		}
-		//by being KSortable with the same timestamp, it means the sequence is Not empty, and it is monotonic
-		uuids := make([]UUID, 10)
+		//by being KSortable with the same timestamp, it means the sequence is Not empty, and it is monotonic.
+		//The count is well past the 4096 values the 12 bit counter can hold, so a rollover has to be
+		//handled without breaking the ordering.
+		uuids := make([]UUID, 5000)
 		for i := range uuids {
 			u, err := g.NewV7()
 			testErrCheck(t, "NewV7()", "", err)
 			uuids[i] = u
 		}
 
-		for i := 1; i < len(uuids); i++ {
-			p, n := uuids[i-1], uuids[i]
-			isLess := p.String() < n.String()
-			if !isLess {
-				t.Errorf("uuids[%d] (%s) not less than uuids[%d] (%s)", i-1, p, i, n)
+		assertV7Increasing(t, uuids)
+	}
+}
+
+// makeTestNewV7CounterRollover generates far more UUIDs within a single
+// millisecond than the 12 bit counter can hold, which is where the counter used
+// to wrap from 0xfff back to 0x000 and reorder UUIDs against their predecessor.
+func makeTestNewV7CounterRollover() func(t *testing.T) {
+	return func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping test in short mode.")
+		}
+
+		g := NewGenWithOptions(WithEpochFunc(func() time.Time {
+			return time.UnixMilli(1645557742000)
+		}))
+
+		uuids := make([]UUID, 50000)
+		for i := range uuids {
+			u, err := g.NewV7()
+			testErrCheck(t, "NewV7()", "", err)
+			uuids[i] = u
+		}
+
+		assertV7Increasing(t, uuids)
+	}
+}
+
+// makeTestNewV7BorrowIsBounded checks the cost of the rollover handling: the
+// embedded timestamp runs ahead of the real one, but only by as many
+// milliseconds as there were counter rollovers.
+func makeTestNewV7BorrowIsBounded() func(t *testing.T) {
+	return func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping test in short mode.")
+		}
+
+		const (
+			count  = 50000
+			atMs   = 1645557742000
+			usable = maxV7Counter - v7CounterSeedMask // increments guaranteed within a tick
+		)
+
+		g := NewGenWithOptions(WithEpochFunc(func() time.Time {
+			return time.UnixMilli(atMs)
+		}))
+
+		var last UUID
+		for range count {
+			u, err := g.NewV7()
+			testErrCheck(t, "NewV7()", "", err)
+			last = u
+		}
+
+		ts, err := TimestampFromV7(last)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := ts.Time()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ahead := got.UnixMilli() - atMs
+		if ahead < 0 {
+			t.Fatalf("timestamp went backwards by %dms", -ahead)
+		}
+		if want := int64(count/usable + 1); ahead > want {
+			t.Errorf("timestamp ran %dms ahead of the clock, want at most %dms", ahead, want)
+		}
+	}
+}
+
+// makeTestNewV7CounterReseedsOnNewTick pins the random reader so the counter is
+// predictable, then checks that a new millisecond reseeds it from that reader
+// rather than continuing to climb, and that all 12 bits survive SetVersion.
+func makeTestNewV7CounterReseedsOnNewTick() func(t *testing.T) {
+	return func(t *testing.T) {
+		// Two counter seeds, each followed by the 8 bytes read for rand_b.
+		seeds := []uint16{0xabcd, 0x1234}
+		buf := make([]byte, 0, 2*(2+8))
+		for _, seed := range seeds {
+			buf = binary.BigEndian.AppendUint16(buf, seed)
+			buf = append(buf, make([]byte, 8)...)
+		}
+
+		ms := int64(1645557742000)
+		g := NewGenWithOptions(
+			WithRandomReader(bytes.NewReader(buf)),
+			WithEpochFunc(func() time.Time { return time.UnixMilli(ms) }),
+		)
+
+		first, err := g.NewV7()
+		if err != nil {
+			t.Fatal(err)
+		}
+		ms++
+		second, err := g.NewV7()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for i, u := range []UUID{first, second} {
+			// The guard bit keeps the counter in the lower half of its range,
+			// leaving room to increment within the tick.
+			want := seeds[i] & v7CounterSeedMask
+			if got := v7Counter(u); got != want {
+				t.Errorf("uuid %d: got counter %#03x, want %#03x", i, got, want)
 			}
+		}
+		if first.String() >= second.String() {
+			t.Errorf("%v is not less than %v", first, second)
+		}
+	}
+}
+
+// makeTestNewV7MixedWithV1 guards against V7 sharing counter and timestamp state
+// with V1. V1 counts its epoch in 100 nanosecond intervals since 1582, which
+// dwarfs any millisecond value V7 compares against, and its clock sequence is 14
+// bits wide rather than 12. The timestamp is pinned so that every UUID lands in
+// the same tick, leaving the counter as the only thing keeping them in order.
+func makeTestNewV7MixedWithV1() func(t *testing.T) {
+	return func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping test in short mode.")
+		}
+
+		const atMs = 1645557742000
+
+		g := NewGenWithOptions(WithEpochFunc(func() time.Time {
+			return time.UnixMilli(atMs)
+		}))
+
+		uuids := make([]UUID, 5000)
+		for i := range uuids {
+			if _, err := g.NewV1(); err != nil {
+				t.Fatal(err)
+			}
+			u, err := g.NewV7()
+			if err != nil {
+				t.Fatal(err)
+			}
+			uuids[i] = u
+		}
+
+		assertV7Increasing(t, uuids)
+
+		// The V1 epoch must not have been mistaken for a millisecond count and
+		// left in the V7 timestamp field.
+		ts, err := TimestampFromV7(uuids[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := ts.Time()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.UnixMilli() != atMs {
+			t.Errorf("first UUID encodes %v (%dms), want the provided %dms", got.UTC(), got.UnixMilli(), atMs)
+		}
+	}
+}
+
+// makeTestNewV7BackwardsClock checks that a clock correction cannot reorder
+// UUIDs, per the monotonic error checking guidance in RFC 9562 section 6.2.
+func makeTestNewV7BackwardsClock() func(t *testing.T) {
+	return func(t *testing.T) {
+		ms := int64(1645557742000)
+		g := NewGenWithOptions(WithEpochFunc(func() time.Time {
+			return time.UnixMilli(ms)
+		}))
+
+		uuids := make([]UUID, 0, 30)
+		for _, step := range []int64{1, 1, -5000, 1, -1, 2} {
+			for range 5 {
+				u, err := g.NewV7()
+				if err != nil {
+					t.Fatal(err)
+				}
+				uuids = append(uuids, u)
+			}
+			ms += step
+		}
+
+		assertV7Increasing(t, uuids)
+	}
+}
+
+// makeTestNewV7AtTimeHistorical checks that the protection against a backwards
+// clock does not leak into the explicit timestamp API: a caller asking for an
+// older timestamp gets that timestamp, and a batch at that timestamp stays
+// ordered.
+func makeTestNewV7AtTimeHistorical() func(t *testing.T) {
+	return func(t *testing.T) {
+		g := NewGen()
+
+		if _, err := g.NewV7(); err != nil {
+			t.Fatal(err)
+		}
+
+		atTime := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+		uuids := make([]UUID, 10)
+		for i := range uuids {
+			u, err := g.NewV7AtTime(atTime)
+			if err != nil {
+				t.Fatal(err)
+			}
+			uuids[i] = u
+		}
+
+		assertV7Increasing(t, uuids)
+
+		for i, u := range uuids {
+			ts, err := TimestampFromV7(u)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := ts.Time()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !got.Equal(atTime) {
+				t.Fatalf("uuids[%d] encodes %v, want the provided %v", i, got.UTC(), atTime)
+			}
+		}
+	}
+}
+
+// makeTestNewV7AtTimeUnrepresentable covers times the 48-bit millisecond field
+// cannot hold, such as the zero time. They are pinned to the nearest end of the
+// range, and must not drag the generator along with them: without that, the
+// negative millisecond count of a zero time would read as a timestamp far in the
+// future and hold every later UUID there.
+func makeTestNewV7AtTimeUnrepresentable() func(t *testing.T) {
+	return func(t *testing.T) {
+		for _, tt := range []struct {
+			name   string
+			atTime time.Time
+			want   int64
+		}{
+			{name: "ZeroTime", atTime: time.Time{}, want: 0},
+			{name: "BeforeUnixEpoch", atTime: time.Date(1969, 7, 20, 20, 17, 0, 0, time.UTC), want: 0},
+			{name: "AfterTimestampRange", atTime: time.Date(20000, 1, 1, 0, 0, 0, 0, time.UTC), want: maxV7Timestamp},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				g := NewGen()
+
+				u, err := g.NewV7AtTime(tt.atTime)
+				if err != nil {
+					t.Fatal(err)
+				}
+				ts, err := TimestampFromV7(u)
+				if err != nil {
+					t.Fatal(err)
+				}
+				got, err := ts.Time()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got.UnixMilli() != tt.want {
+					t.Errorf("%v encodes %dms, want %dms", u, got.UnixMilli(), tt.want)
+				}
+
+				next, err := g.NewV7()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if u.String() >= next.String() {
+					t.Errorf("%v is not less than %v", u, next)
+				}
+
+				if tt.want > 0 {
+					// A timestamp ahead of the clock holds the generator there,
+					// so there is nothing more to check.
+					return
+				}
+
+				// A timestamp below the clock leaves the generator tracking it.
+				ts, err = TimestampFromV7(next)
+				if err != nil {
+					t.Fatal(err)
+				}
+				got, err = ts.Time()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if drift := time.Since(got); drift < 0 || drift > time.Minute {
+					t.Errorf("%v is %v away from now", next, drift)
+				}
+			})
+		}
+	}
+}
+
+// makeTestNewV7Concurrent checks that no two UUIDs from one generator share a
+// timestamp and counter, which is the pair the ordering guarantee rests on.
+func makeTestNewV7Concurrent() func(t *testing.T) {
+	return func(t *testing.T) {
+		const (
+			goroutines = 8
+			perRoutine = 2000
+		)
+
+		g := NewGen()
+
+		var wg sync.WaitGroup
+		results := make([][]UUID, goroutines)
+		for i := range results {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+
+				uuids := make([]UUID, perRoutine)
+				for j := range uuids {
+					u, err := g.NewV7()
+					if err != nil {
+						t.Error(err)
+						return
+					}
+					uuids[j] = u
+				}
+				results[i] = uuids
+			}(i)
+		}
+		wg.Wait()
+
+		if t.Failed() {
+			return
+		}
+
+		type sequence struct {
+			ms      uint64
+			counter uint16
+		}
+		seen := make(map[sequence]UUID, goroutines*perRoutine)
+		for _, uuids := range results {
+			for _, u := range uuids {
+				ts, err := TimestampFromV7(u)
+				if err != nil {
+					t.Fatal(err)
+				}
+				key := sequence{ms: uint64(ts), counter: v7Counter(u)}
+				if prev, ok := seen[key]; ok {
+					t.Fatalf("%v and %v share a timestamp and counter", prev, u)
+				}
+				seen[key] = u
+			}
+		}
+	}
+}
+
+// makeTestNewV7FaultyRandOnReseed fails the read that seeds the counter for a
+// new millisecond.
+func makeTestNewV7FaultyRandOnReseed() func(t *testing.T) {
+	return func(t *testing.T) {
+		ms := int64(1645557742000)
+		g := NewGenWithOptions(
+			WithRandomReader(&seedFailReader{failOn: 2}),
+			WithEpochFunc(func() time.Time { return time.UnixMilli(ms) }),
+		)
+
+		if _, err := g.NewV7(); err != nil {
+			t.Fatal(err)
+		}
+
+		ms++
+		u, err := g.NewV7()
+		if err == nil {
+			t.Errorf("got %v, nil error for the counter reseed", u)
+		}
+		if u != Nil {
+			t.Errorf("got %v on error, want Nil", u)
+		}
+	}
+}
+
+// makeTestNewV7FaultyRandOnRollover fails the read that reseeds the counter
+// after it is exhausted within a millisecond. Seeding the counter as high as the
+// guard bit allows also pins down the guaranteed headroom within a tick.
+func makeTestNewV7FaultyRandOnRollover() func(t *testing.T) {
+	return func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping test in short mode.")
+		}
+
+		g := NewGenWithOptions(
+			WithRandomReader(&seedFailReader{failOn: 2}),
+			WithEpochFunc(func() time.Time { return time.UnixMilli(1645557742000) }),
+		)
+
+		first, err := g.NewV7()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := v7Counter(first), uint16(v7CounterSeedMask); got != want {
+			t.Fatalf("got counter %#03x, want %#03x", got, want)
+		}
+
+		for i := range maxV7Counter - v7CounterSeedMask {
+			u, err := g.NewV7()
+			if err != nil {
+				t.Fatalf("uuid %d: unexpected error: %v", i, err)
+			}
+			if got, want := v7Counter(u), uint16(v7CounterSeedMask+1+i); got != want {
+				t.Fatalf("uuid %d: got counter %#03x, want %#03x", i, got, want)
+			}
+		}
+
+		u, err := g.NewV7()
+		if err == nil {
+			t.Errorf("got %v, nil error for the counter rollover", u)
+		}
+		if u != Nil {
+			t.Errorf("got %v on error, want Nil", u)
 		}
 	}
 }
@@ -971,12 +1410,16 @@ func makeTestNewV7AtTime() func(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Even with the same timestamp, there is still a random portion,
-		// so they should not be 100% identical. Bytes 0-6 are the timestamp so they should be identical.
-		u1Bytes := u1.Bytes()[:7]
-		u2Bytes := u2.Bytes()[:7]
+		// Bytes 0-5 hold the 48 bit timestamp, so they should be identical. The
+		// remaining bytes carry the monotonic counter and the random portion,
+		// which must differ so that the second UUID sorts above the first.
+		u1Bytes := u1.Bytes()[:6]
+		u2Bytes := u2.Bytes()[:6]
 		if !bytes.Equal(u1Bytes, u2Bytes) {
 			t.Errorf("generated different UUIDs across calls with same timestamp: %v / %v", u1, u2)
+		}
+		if u1.String() >= u2.String() {
+			t.Errorf("%v is not less than %v", u1, u2)
 		}
 
 		ts1, err := TimestampFromV7(u1)
@@ -1145,6 +1588,31 @@ func (r *faultyReader) Read(dest []byte) (int, error) {
 		return 0, fmt.Errorf("io: reader is faulty")
 	}
 	return rand.Read(dest)
+}
+
+// seedFailReader fails a chosen V7 counter seed and serves every other seed as
+// 0xffff, which the guard bit trims to the highest value a seed can take. V7
+// reads exactly two bytes for the counter seed and eight for rand_b, so the
+// length of the read identifies which is being served.
+type seedFailReader struct {
+	seeds  int
+	failOn int // seed number to fail, counting from one
+}
+
+func (r *seedFailReader) Read(dest []byte) (int, error) {
+	if len(dest) != 2 {
+		return rand.Read(dest)
+	}
+
+	r.seeds++
+	if r.seeds == r.failOn {
+		return 0, fmt.Errorf("io: reader is faulty")
+	}
+	for i := range dest {
+		dest[i] = 0xff
+	}
+
+	return len(dest), nil
 }
 
 // testErrCheck looks to see if errContains is a substring of err.Error(). If

--- a/generator_test.go
+++ b/generator_test.go
@@ -711,6 +711,7 @@ func testNewV7(t *testing.T) {
 	t.Run("KSortable", makeTestNewV7KSortable())
 	t.Run("ClockSequence", makeTestNewV7ClockSequence())
 	t.Run("CounterRollover", makeTestNewV7CounterRollover())
+	t.Run("Sequential1000000", makeTestNewV7Sequential1000000())
 	t.Run("BorrowIsBounded", makeTestNewV7BorrowIsBounded())
 	t.Run("CounterReseedsOnNewTick", makeTestNewV7CounterReseedsOnNewTick())
 	t.Run("MixedWithV1", makeTestNewV7MixedWithV1())
@@ -1004,6 +1005,34 @@ func makeTestNewV7CounterRollover() func(t *testing.T) {
 		}
 
 		assertV7Increasing(t, uuids)
+	}
+}
+
+// makeTestNewV7Sequential1000000 is the ordering check at load, against the real
+// clock so that counter rollovers, the reseeding that follows them and the clock
+// advancing on its own all interleave. Sorting strictly above the previous UUID
+// also means differing from it, so this covers uniqueness across the run. UUIDs
+// are compared as they are generated rather than collected first, to keep the
+// count free to grow.
+func makeTestNewV7Sequential1000000() func(t *testing.T) {
+	return func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping test in short mode.")
+		}
+
+		g := NewGen()
+
+		var prev string
+		for i := range 1000000 {
+			u, err := g.NewV7()
+			testErrCheck(t, "NewV7()", "", err)
+
+			cur := u.String()
+			if cur <= prev {
+				t.Fatalf("uuids[%d] (%s) not less than uuids[%d] (%s)", i-1, prev, i, cur)
+			}
+			prev = cur
+		}
 	}
 }
 

--- a/generator_test.go
+++ b/generator_test.go
@@ -760,9 +760,10 @@ func makeTestNewV7Basic() func(t *testing.T) {
 func makeTestNewV7TestVector() func(t *testing.T) {
 	return func(t *testing.T) {
 		pRand := make([]byte, 10)
-		//first 2 bytes will be read to seed the counter. First 4 bits will be overridden by Version. The next bits should be 0xCC3(3267)
+		// First 2 bytes will be read to seed the counter (11 bits are used; the top bit is cleared as a guard).
+		// The first 4 bits of u[6] will be overridden by the Version field.
 		binary.LittleEndian.PutUint16(pRand[:2], uint16(0xCC3))
-		//8bytes will be read for rand_b. First 2 bits will be overridden by Variant
+		// 8bytes will be read for rand_b. First 2 bits will be overridden by Variant
 		binary.LittleEndian.PutUint64(pRand[2:], uint64(0x18C4DC0C0C07398F))
 
 		g := &Gen{


### PR DESCRIPTION
## Why

`NewV7` documents support for single-node batch generation with a monotonic counter, but roughly one id in every 4096 sorts below its predecessor. In such a pair the 48-bit timestamp and the version nibble are identical while the counter in `rand_a` rolls from `fff` back to `000`.

Three things combined to cause it. `g.clockSequence` was seeded once from random bytes and then only ever incremented, never reset when the timestamp advanced, so its wrap point had no relationship to millisecond boundaries. `NewV7AtTime` wrote the full `uint16` to bytes 6 and 7 and then called `SetVersion(V7)`, which overwrites the high 4 bits, so only the low 12 bits reached the id and the encoded counter wrapped every 4096 generations. Finally, `lastTime` was shared between V1 and V6, which count 100-nanosecond intervals since 1582, and V7, which counts milliseconds since 1970. On a generator producing both, the V1 value dwarfs any V7 millisecond, so every V7 call took the "clock didn't change" branch and incremented the counter regardless of the millisecond, reaching the wrap sooner.

Because the counter was seeded randomly, the first wrap landed after an arbitrary 0 to 4095 ids and in a different place on every process start, which is why this surfaces as intermittent misordering in downstream systems rather than as an obvious failure. The existing `ClockSequence` test asserted ordering over 10 ids, which straddles the 12-bit boundary with probability near 0.24% and so passed essentially always.

## What

V7 now has its own counter state and its own code path, and no longer calls `getClockSequence`. Separate state is the smallest correct fix because one counter cannot serve both callers: V1 writes to bytes 8 and 9 where `SetVariant` claims 2 bits, leaving 14 usable, while V7 writes to bytes 6 and 7 where `SetVersion` claims 4, leaving 12. Any single mask is wrong for one of them. Splitting the state also resolves the unit mismatch described above, so V1 and V7 no longer interfere on a shared generator.

The counter is a dedicated 12-bit field as described by [RFC 9562 section 6.2, Method 1](https://datatracker.ietf.org/doc/html/rfc9562#section-6.2). It is reseeded from 11 random bits at the start of each millisecond, with the leading bit left zero as a rollover guard, following the "Fixed Bit-Length Dedicated Counter Seeding" guidance. Seeding randomly rather than from zero keeps the entropy the previous implementation had in `rand_a`, and the guard bit guarantees at least 2048 increments within a tick regardless of the seed drawn.

When the counter is exhausted within a tick, the embedded timestamp is incremented ahead of the actual time and the counter reseeded. RFC 9562 section 6.2 permits either this or freezing the counter until the clock advances. Freezing is not available here, because the timestamp can be supplied by the caller through `NewV7AtTime` or by a fixed `EpochFunc`, and is then under no obligation to ever advance; waiting on it would hang. The cost is bounded and observable: the timestamp runs ahead by one millisecond per rollover, so it stays accurate below roughly two million ids per second.

`NewV7` and `NewV7AtTime` now differ in how they treat a timestamp that moves backwards, and both call a shared `newV7` with a flag that selects the behavior. `NewV7` reads the clock itself, so a timestamp below the last one used means the clock was corrected backwards, and it is held at the last value to keep ordering intact, per the "Monotonic Error Checking" guidance in the same section. `NewV7AtTime` receives its timestamp from the caller, so an older timestamp is a deliberate request for an older id and is encoded as given, with the counter restarting there. Clamping in that case would mean `uuid.NewV7AtTime(historicalTime)` silently returning the current time on the package level default generator, which is a worse outcome than the caller getting the timestamp they asked for. The consequence, that ordering under `NewV7AtTime` only holds for timestamps that do not move backwards, is now stated in its documentation, along with the fact that a timestamp ahead of the clock holds subsequent `NewV7` ids at that timestamp.

Timestamps outside the range the 48-bit millisecond field can represent are pinned to the nearest end of that range before they reach the counter state. Without this, the negative `UnixMilli` of a zero `time.Time` would convert to a value near 1.8e19, enter the state as a timestamp far in the future, and hold every subsequent id from that generator there.

Two smaller changes come with it. The `useUnixTSMs` parameter on `getClockSequence` is dead once V7 stops calling it, so it and its branch are removed in a separate commit. The `AtSpecificTime` test compared the first 7 bytes of two ids sharing a timestamp; byte 6 now carries counter bits by design, so it compares the 6 timestamp bytes and asserts ordering instead.

This does not conflict with #219. Its 14-bit mask is correct for V1 and wrong for V7, and removing V7 from the shared helper leaves that patch correct as written for the only versions still using it.

## Verification

The reproduction from the issue goes from 3 inversions in 10,000 pinned-epoch ids and 5 in 20,000 real-clock ids to 0 in both. Ten new subtests cover rollover across 50,000 ids in one millisecond, the bound on how far the timestamp runs ahead, reseeding on a new tick, interleaving with V1, a backwards clock, historical and unrepresentable timestamps, concurrency, and both random-source failure paths. `CounterRollover` and `MixedWithV1` were confirmed to fail against unpatched master. Statement coverage stays at 100%, and `BenchmarkGenerator/NewV7` is unchanged at about 92 ns/op with one allocation, even though the benchmark generates around 10,000 ids per millisecond and therefore rolls the counter over continuously.
